### PR TITLE
Update BrickOwlClient.cs

### DIFF
--- a/BrickOwlSharp.Client/BrickOwlClient.cs
+++ b/BrickOwlSharp.Client/BrickOwlClient.cs
@@ -302,7 +302,7 @@ namespace BrickOwlSharp.Client
             var url = new Uri(_baseUri, $"inventory/update").ToString();
             BrickOwlResult result = await ExecutePost<BrickOwlResult>(url, formData, cancellationToken: cancellationToken);
             _measureRequest(ResourceType.Inventory, cancellationToken);
-            return (result?.Status == "success");
+            return result.Status?.Equals("success", StringComparison.OrdinalIgnoreCase) == true;
         } // !UpdateInventoryAsync()
 
 


### PR DESCRIPTION
Fix: Correct BrickOwl UpdateInventoryAsync success detection

- Added case-insensitive check for "success" status in BrickOwlResult
- Resolves false negatives where API returned "Success" but method returned false
- Verified updates now correctly report success instead of soft-fail
- Local build now used instead of NuGet package for consistent behavior

## Summary
- What changed and why?

## Checklist
- [ ] Code follows repo **Coding Instructions**
- [ ] Public APIs documented (XML)
- [ ] Unit tests added/updated
- [ ] No blocking async (`.Result` / `GetAwaiter().GetResult()`)
- [ ] `CancellationToken` respected
- [ ] Analyzers clean (`dotnet build` no warnings as errors)
- [ ] `dotnet format --verify-no-changes` passes

## Breaking changes?
- [x] No
- [ ] Yes (explain impact & migration)