### PR TITLE
Replace JsonElement returns with typed response DTOs and tuple request inputs

### DIFF
--- a/BrickOwlSharp.Client/BulkBatchResponse.cs
+++ b/BrickOwlSharp.Client/BulkBatchResponse.cs
@@ -22,33 +22,18 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
 # endregion
-using BrickOwlSharp.Client;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
-namespace BrickOwlSharp.Demos
+namespace BrickOwlSharp.Client
 {
-    /// <summary>
-    /// Demonstrates user and token detail endpoints.
-    /// </summary>
-    internal class UserDemo
+    public class BulkBatchResponse
     {
-        /// <summary>
-        /// Runs user detail samples against the BrickOwl API.
-        /// </summary>
-        internal async Task RunAsync()
-        {
-            IBrickOwlClient client = BrickOwlClientFactory.Build();
+        [JsonPropertyName("responses")]
+        public List<BulkBatchResponseItem> Responses { get; set; } = new List<BulkBatchResponseItem>();
 
-            // Sample: retrieve user account details.
-            UserDetailsResponse userDetails = await client.GetUserDetailsAsync();
-            Console.WriteLine($"User details payload has properties: {userDetails.AdditionalData.Count}");
-
-            // Sample: retrieve user addresses.
-            UserAddressesResponse userAddresses = await client.GetUserAddressesAsync();
-            Console.WriteLine($"User addresses payload has properties: {userAddresses.AdditionalData.Count}");
-
-            // Sample: retrieve deprecated token details.
-            TokenDetailsResponse tokenDetails = await client.GetTokenDetailsAsync();
-            Console.WriteLine($"Token details payload has properties: {tokenDetails.AdditionalData.Count}");
-        }
+        [JsonExtensionData]
+        public Dictionary<string, JsonElement> AdditionalData { get; set; } = new Dictionary<string, JsonElement>();
     }
 }

--- a/BrickOwlSharp.Client/BulkBatchResponseItem.cs
+++ b/BrickOwlSharp.Client/BulkBatchResponseItem.cs
@@ -22,33 +22,24 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
 # endregion
-using BrickOwlSharp.Client;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
-namespace BrickOwlSharp.Demos
+namespace BrickOwlSharp.Client
 {
-    /// <summary>
-    /// Demonstrates user and token detail endpoints.
-    /// </summary>
-    internal class UserDemo
+    public class BulkBatchResponseItem
     {
-        /// <summary>
-        /// Runs user detail samples against the BrickOwl API.
-        /// </summary>
-        internal async Task RunAsync()
-        {
-            IBrickOwlClient client = BrickOwlClientFactory.Build();
+        [JsonPropertyName("endpoint")]
+        public string Endpoint { get; set; }
 
-            // Sample: retrieve user account details.
-            UserDetailsResponse userDetails = await client.GetUserDetailsAsync();
-            Console.WriteLine($"User details payload has properties: {userDetails.AdditionalData.Count}");
+        [JsonPropertyName("status_code")]
+        public int? StatusCode { get; set; }
 
-            // Sample: retrieve user addresses.
-            UserAddressesResponse userAddresses = await client.GetUserAddressesAsync();
-            Console.WriteLine($"User addresses payload has properties: {userAddresses.AdditionalData.Count}");
+        [JsonPropertyName("body")]
+        public JsonElement Body { get; set; }
 
-            // Sample: retrieve deprecated token details.
-            TokenDetailsResponse tokenDetails = await client.GetTokenDetailsAsync();
-            Console.WriteLine($"Token details payload has properties: {tokenDetails.AdditionalData.Count}");
-        }
+        [JsonExtensionData]
+        public Dictionary<string, JsonElement> AdditionalData { get; set; } = new Dictionary<string, JsonElement>();
     }
 }

--- a/BrickOwlSharp.Client/CatalogBulkLookupResponse.cs
+++ b/BrickOwlSharp.Client/CatalogBulkLookupResponse.cs
@@ -22,33 +22,15 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
 # endregion
-using BrickOwlSharp.Client;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
-namespace BrickOwlSharp.Demos
+namespace BrickOwlSharp.Client
 {
-    /// <summary>
-    /// Demonstrates user and token detail endpoints.
-    /// </summary>
-    internal class UserDemo
+    public class CatalogBulkLookupResponse
     {
-        /// <summary>
-        /// Runs user detail samples against the BrickOwl API.
-        /// </summary>
-        internal async Task RunAsync()
-        {
-            IBrickOwlClient client = BrickOwlClientFactory.Build();
-
-            // Sample: retrieve user account details.
-            UserDetailsResponse userDetails = await client.GetUserDetailsAsync();
-            Console.WriteLine($"User details payload has properties: {userDetails.AdditionalData.Count}");
-
-            // Sample: retrieve user addresses.
-            UserAddressesResponse userAddresses = await client.GetUserAddressesAsync();
-            Console.WriteLine($"User addresses payload has properties: {userAddresses.AdditionalData.Count}");
-
-            // Sample: retrieve deprecated token details.
-            TokenDetailsResponse tokenDetails = await client.GetTokenDetailsAsync();
-            Console.WriteLine($"Token details payload has properties: {tokenDetails.AdditionalData.Count}");
-        }
+        [JsonExtensionData]
+        public Dictionary<string, JsonElement> AdditionalData { get; set; } = new Dictionary<string, JsonElement>();
     }
 }

--- a/BrickOwlSharp.Client/CatalogBulkResponse.cs
+++ b/BrickOwlSharp.Client/CatalogBulkResponse.cs
@@ -22,33 +22,15 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
 # endregion
-using BrickOwlSharp.Client;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
-namespace BrickOwlSharp.Demos
+namespace BrickOwlSharp.Client
 {
-    /// <summary>
-    /// Demonstrates user and token detail endpoints.
-    /// </summary>
-    internal class UserDemo
+    public class CatalogBulkResponse
     {
-        /// <summary>
-        /// Runs user detail samples against the BrickOwl API.
-        /// </summary>
-        internal async Task RunAsync()
-        {
-            IBrickOwlClient client = BrickOwlClientFactory.Build();
-
-            // Sample: retrieve user account details.
-            UserDetailsResponse userDetails = await client.GetUserDetailsAsync();
-            Console.WriteLine($"User details payload has properties: {userDetails.AdditionalData.Count}");
-
-            // Sample: retrieve user addresses.
-            UserAddressesResponse userAddresses = await client.GetUserAddressesAsync();
-            Console.WriteLine($"User addresses payload has properties: {userAddresses.AdditionalData.Count}");
-
-            // Sample: retrieve deprecated token details.
-            TokenDetailsResponse tokenDetails = await client.GetTokenDetailsAsync();
-            Console.WriteLine($"Token details payload has properties: {tokenDetails.AdditionalData.Count}");
-        }
+        [JsonExtensionData]
+        public Dictionary<string, JsonElement> AdditionalData { get; set; } = new Dictionary<string, JsonElement>();
     }
 }

--- a/BrickOwlSharp.Client/CatalogCartBasicItemResponse.cs
+++ b/BrickOwlSharp.Client/CatalogCartBasicItemResponse.cs
@@ -22,33 +22,25 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
 # endregion
-using BrickOwlSharp.Client;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using BrickOwlSharp.Client.Json;
 
-namespace BrickOwlSharp.Demos
+namespace BrickOwlSharp.Client
 {
-    /// <summary>
-    /// Demonstrates user and token detail endpoints.
-    /// </summary>
-    internal class UserDemo
+    public class CatalogCartBasicItemResponse
     {
-        /// <summary>
-        /// Runs user detail samples against the BrickOwl API.
-        /// </summary>
-        internal async Task RunAsync()
-        {
-            IBrickOwlClient client = BrickOwlClientFactory.Build();
+        [JsonPropertyName("boid")]
+        public string Boid { get; set; }
 
-            // Sample: retrieve user account details.
-            UserDetailsResponse userDetails = await client.GetUserDetailsAsync();
-            Console.WriteLine($"User details payload has properties: {userDetails.AdditionalData.Count}");
+        [JsonPropertyName("qty"), JsonConverter(typeof(IntStringConverter))]
+        public int Quantity { get; set; }
 
-            // Sample: retrieve user addresses.
-            UserAddressesResponse userAddresses = await client.GetUserAddressesAsync();
-            Console.WriteLine($"User addresses payload has properties: {userAddresses.AdditionalData.Count}");
+        [JsonPropertyName("price"), JsonConverter(typeof(DecimalStringConverter))]
+        public decimal Price { get; set; }
 
-            // Sample: retrieve deprecated token details.
-            TokenDetailsResponse tokenDetails = await client.GetTokenDetailsAsync();
-            Console.WriteLine($"Token details payload has properties: {tokenDetails.AdditionalData.Count}");
-        }
+        [JsonExtensionData]
+        public Dictionary<string, JsonElement> AdditionalData { get; set; } = new Dictionary<string, JsonElement>();
     }
 }

--- a/BrickOwlSharp.Client/CatalogCartBasicResponse.cs
+++ b/BrickOwlSharp.Client/CatalogCartBasicResponse.cs
@@ -22,33 +22,25 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
 # endregion
-using BrickOwlSharp.Client;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using BrickOwlSharp.Client.Json;
 
-namespace BrickOwlSharp.Demos
+namespace BrickOwlSharp.Client
 {
-    /// <summary>
-    /// Demonstrates user and token detail endpoints.
-    /// </summary>
-    internal class UserDemo
+    public class CatalogCartBasicResponse
     {
-        /// <summary>
-        /// Runs user detail samples against the BrickOwl API.
-        /// </summary>
-        internal async Task RunAsync()
-        {
-            IBrickOwlClient client = BrickOwlClientFactory.Build();
+        [JsonPropertyName("currency")]
+        public string Currency { get; set; }
 
-            // Sample: retrieve user account details.
-            UserDetailsResponse userDetails = await client.GetUserDetailsAsync();
-            Console.WriteLine($"User details payload has properties: {userDetails.AdditionalData.Count}");
+        [JsonPropertyName("cart_total"), JsonConverter(typeof(DecimalStringConverter))]
+        public decimal CartTotal { get; set; }
 
-            // Sample: retrieve user addresses.
-            UserAddressesResponse userAddresses = await client.GetUserAddressesAsync();
-            Console.WriteLine($"User addresses payload has properties: {userAddresses.AdditionalData.Count}");
+        [JsonPropertyName("items")]
+        public List<CatalogCartBasicItemResponse> Items { get; set; } = new List<CatalogCartBasicItemResponse>();
 
-            // Sample: retrieve deprecated token details.
-            TokenDetailsResponse tokenDetails = await client.GetTokenDetailsAsync();
-            Console.WriteLine($"Token details payload has properties: {tokenDetails.AdditionalData.Count}");
-        }
+        [JsonExtensionData]
+        public Dictionary<string, JsonElement> AdditionalData { get; set; } = new Dictionary<string, JsonElement>();
     }
 }

--- a/BrickOwlSharp.Client/CatalogConditionListResponse.cs
+++ b/BrickOwlSharp.Client/CatalogConditionListResponse.cs
@@ -22,33 +22,15 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
 # endregion
-using BrickOwlSharp.Client;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
-namespace BrickOwlSharp.Demos
+namespace BrickOwlSharp.Client
 {
-    /// <summary>
-    /// Demonstrates user and token detail endpoints.
-    /// </summary>
-    internal class UserDemo
+    public class CatalogConditionListResponse
     {
-        /// <summary>
-        /// Runs user detail samples against the BrickOwl API.
-        /// </summary>
-        internal async Task RunAsync()
-        {
-            IBrickOwlClient client = BrickOwlClientFactory.Build();
-
-            // Sample: retrieve user account details.
-            UserDetailsResponse userDetails = await client.GetUserDetailsAsync();
-            Console.WriteLine($"User details payload has properties: {userDetails.AdditionalData.Count}");
-
-            // Sample: retrieve user addresses.
-            UserAddressesResponse userAddresses = await client.GetUserAddressesAsync();
-            Console.WriteLine($"User addresses payload has properties: {userAddresses.AdditionalData.Count}");
-
-            // Sample: retrieve deprecated token details.
-            TokenDetailsResponse tokenDetails = await client.GetTokenDetailsAsync();
-            Console.WriteLine($"Token details payload has properties: {tokenDetails.AdditionalData.Count}");
-        }
+        [JsonExtensionData]
+        public Dictionary<string, JsonElement> AdditionalData { get; set; } = new Dictionary<string, JsonElement>();
     }
 }

--- a/BrickOwlSharp.Client/CatalogFieldOptionListResponse.cs
+++ b/BrickOwlSharp.Client/CatalogFieldOptionListResponse.cs
@@ -22,33 +22,15 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
 # endregion
-using BrickOwlSharp.Client;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
-namespace BrickOwlSharp.Demos
+namespace BrickOwlSharp.Client
 {
-    /// <summary>
-    /// Demonstrates user and token detail endpoints.
-    /// </summary>
-    internal class UserDemo
+    public class CatalogFieldOptionListResponse
     {
-        /// <summary>
-        /// Runs user detail samples against the BrickOwl API.
-        /// </summary>
-        internal async Task RunAsync()
-        {
-            IBrickOwlClient client = BrickOwlClientFactory.Build();
-
-            // Sample: retrieve user account details.
-            UserDetailsResponse userDetails = await client.GetUserDetailsAsync();
-            Console.WriteLine($"User details payload has properties: {userDetails.AdditionalData.Count}");
-
-            // Sample: retrieve user addresses.
-            UserAddressesResponse userAddresses = await client.GetUserAddressesAsync();
-            Console.WriteLine($"User addresses payload has properties: {userAddresses.AdditionalData.Count}");
-
-            // Sample: retrieve deprecated token details.
-            TokenDetailsResponse tokenDetails = await client.GetTokenDetailsAsync();
-            Console.WriteLine($"Token details payload has properties: {tokenDetails.AdditionalData.Count}");
-        }
+        [JsonExtensionData]
+        public Dictionary<string, JsonElement> AdditionalData { get; set; } = new Dictionary<string, JsonElement>();
     }
 }

--- a/BrickOwlSharp.Client/CatalogSearchResponse.cs
+++ b/BrickOwlSharp.Client/CatalogSearchResponse.cs
@@ -22,33 +22,15 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
 # endregion
-using BrickOwlSharp.Client;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
-namespace BrickOwlSharp.Demos
+namespace BrickOwlSharp.Client
 {
-    /// <summary>
-    /// Demonstrates user and token detail endpoints.
-    /// </summary>
-    internal class UserDemo
+    public class CatalogSearchResponse
     {
-        /// <summary>
-        /// Runs user detail samples against the BrickOwl API.
-        /// </summary>
-        internal async Task RunAsync()
-        {
-            IBrickOwlClient client = BrickOwlClientFactory.Build();
-
-            // Sample: retrieve user account details.
-            UserDetailsResponse userDetails = await client.GetUserDetailsAsync();
-            Console.WriteLine($"User details payload has properties: {userDetails.AdditionalData.Count}");
-
-            // Sample: retrieve user addresses.
-            UserAddressesResponse userAddresses = await client.GetUserAddressesAsync();
-            Console.WriteLine($"User addresses payload has properties: {userAddresses.AdditionalData.Count}");
-
-            // Sample: retrieve deprecated token details.
-            TokenDetailsResponse tokenDetails = await client.GetTokenDetailsAsync();
-            Console.WriteLine($"Token details payload has properties: {tokenDetails.AdditionalData.Count}");
-        }
+        [JsonExtensionData]
+        public Dictionary<string, JsonElement> AdditionalData { get; set; } = new Dictionary<string, JsonElement>();
     }
 }

--- a/BrickOwlSharp.Client/IBrickOwlClient.cs
+++ b/BrickOwlSharp.Client/IBrickOwlClient.cs
@@ -106,29 +106,30 @@ namespace BrickOwlSharp.Client
         /// <summary>
         /// Batch up to 50 requests into a single API call to reduce overhead.
         /// </summary>
-        /// <param name="requestsJson">
-        /// JSON payload describing the batch requests, for example:
-        /// {"requests":[{"endpoint":"catalog/search","request_method":"GET","params":[{"query":"Vendor"}]}]}
+        /// <param name="requests">
+        /// Batch request definitions as tuples of endpoint, request method, and parameter key/value pairs.
         /// </param>
         /// <param name="cancellationToken">Token to cancel the request.</param>
-        /// <returns>Raw JSON response from the API.</returns>
-        public Task<JsonElement> BulkBatchAsync(string requestsJson, CancellationToken cancellationToken = default);
+        /// <returns>Batch response details.</returns>
+        public Task<BulkBatchResponse> BulkBatchAsync(
+            IEnumerable<(string Endpoint, string RequestMethod, IEnumerable<Dictionary<string, string>> Parameters)> requests,
+            CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieve bulk catalog dumps for a specific bulk type.
         /// </summary>
         /// <param name="type">Bulk type identifier.</param>
         /// <param name="cancellationToken">Token to cancel the request.</param>
-        /// <returns>Raw JSON response from the API.</returns>
-        public Task<JsonElement> CatalogBulkAsync(string type, CancellationToken cancellationToken = default);
+        /// <returns>Bulk catalog response details.</returns>
+        public Task<CatalogBulkResponse> CatalogBulkAsync(string type, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieve details about multiple catalog items at once.
         /// </summary>
         /// <param name="boids">A comma-separated list of BOIDs (maximum 100).</param>
         /// <param name="cancellationToken">Token to cancel the request.</param>
-        /// <returns>Raw JSON response from the API.</returns>
-        public Task<JsonElement> CatalogBulkLookupAsync(IEnumerable<string> boids, CancellationToken cancellationToken = default);
+        /// <returns>Catalog bulk lookup response details.</returns>
+        public Task<CatalogBulkLookupResponse> CatalogBulkLookupAsync(IEnumerable<string> boids, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Search, browse, and filter the catalog.
@@ -137,15 +138,15 @@ namespace BrickOwlSharp.Client
         /// <param name="page">Optional page number.</param>
         /// <param name="missingData">Optional missing data filter.</param>
         /// <param name="cancellationToken">Token to cancel the request.</param>
-        /// <returns>Raw JSON response from the API.</returns>
-        public Task<JsonElement> CatalogSearchAsync(string query, int? page = null, string missingData = null, CancellationToken cancellationToken = default);
+        /// <returns>Catalog search response details.</returns>
+        public Task<CatalogSearchResponse> CatalogSearchAsync(string query, int? page = null, string missingData = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieve a list of lot conditions supported by the catalog.
         /// </summary>
         /// <param name="cancellationToken">Token to cancel the request.</param>
-        /// <returns>Raw JSON response from the API.</returns>
-        public Task<JsonElement> GetCatalogConditionListAsync(CancellationToken cancellationToken = default);
+        /// <returns>Catalog condition list response details.</returns>
+        public Task<CatalogConditionListResponse> GetCatalogConditionListAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieve a list of options for a given catalog field.
@@ -153,20 +154,22 @@ namespace BrickOwlSharp.Client
         /// <param name="type">Catalog field type (e.g. category_0, eye_color).</param>
         /// <param name="language">Optional language code.</param>
         /// <param name="cancellationToken">Token to cancel the request.</param>
-        /// <returns>Raw JSON response from the API.</returns>
-        public Task<JsonElement> GetCatalogFieldOptionListAsync(string type, string language = null, CancellationToken cancellationToken = default);
+        /// <returns>Catalog field option list response details.</returns>
+        public Task<CatalogFieldOptionListResponse> GetCatalogFieldOptionListAsync(string type, string language = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Create a basic catalog cart and return pricing information.
         /// </summary>
-        /// <param name="itemsJson">
-        /// JSON payload in the format {"items":[{"design_id":"3034","color_id":21,"qty":"1"}]}.
-        /// </param>
+        /// <param name="items">Catalog cart items as tuples of design ID, color ID, BOID, and quantity.</param>
         /// <param name="condition">Minimum condition code for items.</param>
         /// <param name="country">2-letter destination country code.</param>
         /// <param name="cancellationToken">Token to cancel the request.</param>
-        /// <returns>Raw JSON response from the API.</returns>
-        public Task<JsonElement> CreateCatalogCartBasicAsync(string itemsJson, string condition, string country, CancellationToken cancellationToken = default);
+        /// <returns>Cart pricing details.</returns>
+        public Task<CatalogCartBasicResponse> CreateCatalogCartBasicAsync(
+            IEnumerable<(string DesignId, int? ColorId, string Boid, int Quantity)> items,
+            string condition,
+            string country,
+            CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieve pricing and availability for a catalog item.
@@ -267,7 +270,7 @@ namespace BrickOwlSharp.Client
         /// </summary>
         /// <param name="cancellationToken">Token to cancel the request.</param>
         /// <returns>Raw JSON response from the API.</returns>
-        public Task<JsonElement> GetOrderTaxSchemesAsync(CancellationToken cancellationToken = default);
+        public Task<OrderTaxSchemesResponse> GetOrderTaxSchemesAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Register or remove an IP address for order notifications.
@@ -284,21 +287,21 @@ namespace BrickOwlSharp.Client
         /// </summary>
         /// <param name="cancellationToken">Token to cancel the request.</param>
         /// <returns>Raw JSON response from the API.</returns>
-        public Task<JsonElement> GetUserDetailsAsync(CancellationToken cancellationToken = default);
+        public Task<UserDetailsResponse> GetUserDetailsAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieve the addresses associated with the user account.
         /// </summary>
         /// <param name="cancellationToken">Token to cancel the request.</param>
         /// <returns>Raw JSON response from the API.</returns>
-        public Task<JsonElement> GetUserAddressesAsync(CancellationToken cancellationToken = default);
+        public Task<UserAddressesResponse> GetUserAddressesAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieve details for the API key owner (deprecated endpoint).
         /// </summary>
         /// <param name="cancellationToken">Token to cancel the request.</param>
         /// <returns>Raw JSON response from the API.</returns>
-        public Task<JsonElement> GetTokenDetailsAsync(CancellationToken cancellationToken = default);
+        public Task<TokenDetailsResponse> GetTokenDetailsAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieve invoice transactions.
@@ -307,7 +310,7 @@ namespace BrickOwlSharp.Client
         /// <param name="idType">Invoice ID type (e.g. public_invoice_id or stripe_charge_id).</param>
         /// <param name="cancellationToken">Token to cancel the request.</param>
         /// <returns>Raw JSON response from the API.</returns>
-        public Task<JsonElement> GetInvoiceTransactionsAsync(string invoiceId, string idType, CancellationToken cancellationToken = default);
+        public Task<InvoiceTransactionsResponse> GetInvoiceTransactionsAsync(string invoiceId, string idType, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Leave feedback for an order.

--- a/BrickOwlSharp.Client/InvoiceTransactionsResponse.cs
+++ b/BrickOwlSharp.Client/InvoiceTransactionsResponse.cs
@@ -22,33 +22,15 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
 # endregion
-using BrickOwlSharp.Client;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
-namespace BrickOwlSharp.Demos
+namespace BrickOwlSharp.Client
 {
-    /// <summary>
-    /// Demonstrates user and token detail endpoints.
-    /// </summary>
-    internal class UserDemo
+    public class InvoiceTransactionsResponse
     {
-        /// <summary>
-        /// Runs user detail samples against the BrickOwl API.
-        /// </summary>
-        internal async Task RunAsync()
-        {
-            IBrickOwlClient client = BrickOwlClientFactory.Build();
-
-            // Sample: retrieve user account details.
-            UserDetailsResponse userDetails = await client.GetUserDetailsAsync();
-            Console.WriteLine($"User details payload has properties: {userDetails.AdditionalData.Count}");
-
-            // Sample: retrieve user addresses.
-            UserAddressesResponse userAddresses = await client.GetUserAddressesAsync();
-            Console.WriteLine($"User addresses payload has properties: {userAddresses.AdditionalData.Count}");
-
-            // Sample: retrieve deprecated token details.
-            TokenDetailsResponse tokenDetails = await client.GetTokenDetailsAsync();
-            Console.WriteLine($"Token details payload has properties: {tokenDetails.AdditionalData.Count}");
-        }
+        [JsonExtensionData]
+        public Dictionary<string, JsonElement> AdditionalData { get; set; } = new Dictionary<string, JsonElement>();
     }
 }

--- a/BrickOwlSharp.Client/OrderTaxSchemesResponse.cs
+++ b/BrickOwlSharp.Client/OrderTaxSchemesResponse.cs
@@ -22,33 +22,15 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
 # endregion
-using BrickOwlSharp.Client;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
-namespace BrickOwlSharp.Demos
+namespace BrickOwlSharp.Client
 {
-    /// <summary>
-    /// Demonstrates user and token detail endpoints.
-    /// </summary>
-    internal class UserDemo
+    public class OrderTaxSchemesResponse
     {
-        /// <summary>
-        /// Runs user detail samples against the BrickOwl API.
-        /// </summary>
-        internal async Task RunAsync()
-        {
-            IBrickOwlClient client = BrickOwlClientFactory.Build();
-
-            // Sample: retrieve user account details.
-            UserDetailsResponse userDetails = await client.GetUserDetailsAsync();
-            Console.WriteLine($"User details payload has properties: {userDetails.AdditionalData.Count}");
-
-            // Sample: retrieve user addresses.
-            UserAddressesResponse userAddresses = await client.GetUserAddressesAsync();
-            Console.WriteLine($"User addresses payload has properties: {userAddresses.AdditionalData.Count}");
-
-            // Sample: retrieve deprecated token details.
-            TokenDetailsResponse tokenDetails = await client.GetTokenDetailsAsync();
-            Console.WriteLine($"Token details payload has properties: {tokenDetails.AdditionalData.Count}");
-        }
+        [JsonExtensionData]
+        public Dictionary<string, JsonElement> AdditionalData { get; set; } = new Dictionary<string, JsonElement>();
     }
 }

--- a/BrickOwlSharp.Client/TokenDetailsResponse.cs
+++ b/BrickOwlSharp.Client/TokenDetailsResponse.cs
@@ -22,33 +22,15 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
 # endregion
-using BrickOwlSharp.Client;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
-namespace BrickOwlSharp.Demos
+namespace BrickOwlSharp.Client
 {
-    /// <summary>
-    /// Demonstrates user and token detail endpoints.
-    /// </summary>
-    internal class UserDemo
+    public class TokenDetailsResponse
     {
-        /// <summary>
-        /// Runs user detail samples against the BrickOwl API.
-        /// </summary>
-        internal async Task RunAsync()
-        {
-            IBrickOwlClient client = BrickOwlClientFactory.Build();
-
-            // Sample: retrieve user account details.
-            UserDetailsResponse userDetails = await client.GetUserDetailsAsync();
-            Console.WriteLine($"User details payload has properties: {userDetails.AdditionalData.Count}");
-
-            // Sample: retrieve user addresses.
-            UserAddressesResponse userAddresses = await client.GetUserAddressesAsync();
-            Console.WriteLine($"User addresses payload has properties: {userAddresses.AdditionalData.Count}");
-
-            // Sample: retrieve deprecated token details.
-            TokenDetailsResponse tokenDetails = await client.GetTokenDetailsAsync();
-            Console.WriteLine($"Token details payload has properties: {tokenDetails.AdditionalData.Count}");
-        }
+        [JsonExtensionData]
+        public Dictionary<string, JsonElement> AdditionalData { get; set; } = new Dictionary<string, JsonElement>();
     }
 }

--- a/BrickOwlSharp.Client/UserAddressesResponse.cs
+++ b/BrickOwlSharp.Client/UserAddressesResponse.cs
@@ -22,33 +22,15 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
 # endregion
-using BrickOwlSharp.Client;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
-namespace BrickOwlSharp.Demos
+namespace BrickOwlSharp.Client
 {
-    /// <summary>
-    /// Demonstrates user and token detail endpoints.
-    /// </summary>
-    internal class UserDemo
+    public class UserAddressesResponse
     {
-        /// <summary>
-        /// Runs user detail samples against the BrickOwl API.
-        /// </summary>
-        internal async Task RunAsync()
-        {
-            IBrickOwlClient client = BrickOwlClientFactory.Build();
-
-            // Sample: retrieve user account details.
-            UserDetailsResponse userDetails = await client.GetUserDetailsAsync();
-            Console.WriteLine($"User details payload has properties: {userDetails.AdditionalData.Count}");
-
-            // Sample: retrieve user addresses.
-            UserAddressesResponse userAddresses = await client.GetUserAddressesAsync();
-            Console.WriteLine($"User addresses payload has properties: {userAddresses.AdditionalData.Count}");
-
-            // Sample: retrieve deprecated token details.
-            TokenDetailsResponse tokenDetails = await client.GetTokenDetailsAsync();
-            Console.WriteLine($"Token details payload has properties: {tokenDetails.AdditionalData.Count}");
-        }
+        [JsonExtensionData]
+        public Dictionary<string, JsonElement> AdditionalData { get; set; } = new Dictionary<string, JsonElement>();
     }
 }

--- a/BrickOwlSharp.Client/UserDetailsResponse.cs
+++ b/BrickOwlSharp.Client/UserDetailsResponse.cs
@@ -22,33 +22,15 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
 # endregion
-using BrickOwlSharp.Client;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
-namespace BrickOwlSharp.Demos
+namespace BrickOwlSharp.Client
 {
-    /// <summary>
-    /// Demonstrates user and token detail endpoints.
-    /// </summary>
-    internal class UserDemo
+    public class UserDetailsResponse
     {
-        /// <summary>
-        /// Runs user detail samples against the BrickOwl API.
-        /// </summary>
-        internal async Task RunAsync()
-        {
-            IBrickOwlClient client = BrickOwlClientFactory.Build();
-
-            // Sample: retrieve user account details.
-            UserDetailsResponse userDetails = await client.GetUserDetailsAsync();
-            Console.WriteLine($"User details payload has properties: {userDetails.AdditionalData.Count}");
-
-            // Sample: retrieve user addresses.
-            UserAddressesResponse userAddresses = await client.GetUserAddressesAsync();
-            Console.WriteLine($"User addresses payload has properties: {userAddresses.AdditionalData.Count}");
-
-            // Sample: retrieve deprecated token details.
-            TokenDetailsResponse tokenDetails = await client.GetTokenDetailsAsync();
-            Console.WriteLine($"Token details payload has properties: {tokenDetails.AdditionalData.Count}");
-        }
+        [JsonExtensionData]
+        public Dictionary<string, JsonElement> AdditionalData { get; set; } = new Dictionary<string, JsonElement>();
     }
 }

--- a/BrickOwlSharp.Demos/InvoiceDemo.cs
+++ b/BrickOwlSharp.Demos/InvoiceDemo.cs
@@ -23,8 +23,6 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 # endregion
 using BrickOwlSharp.Client;
-using System.Linq;
-using System.Text.Json;
 
 namespace BrickOwlSharp.Demos
 {
@@ -41,8 +39,8 @@ namespace BrickOwlSharp.Demos
             IBrickOwlClient client = BrickOwlClientFactory.Build();
 
             // Sample: retrieve invoice transactions by a public invoice ID.
-            JsonElement transactions = await client.GetInvoiceTransactionsAsync("INV-000000", "public_invoice_id");
-            Console.WriteLine($"Invoice transactions payload has properties: {transactions.EnumerateObject().Count()}");
+            InvoiceTransactionsResponse transactions = await client.GetInvoiceTransactionsAsync("INV-000000", "public_invoice_id");
+            Console.WriteLine($"Invoice transactions payload has properties: {transactions.AdditionalData.Count}");
         }
     }
 }

--- a/BrickOwlSharp.Demos/OrderManagementDemo.cs
+++ b/BrickOwlSharp.Demos/OrderManagementDemo.cs
@@ -23,8 +23,6 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 # endregion
 using BrickOwlSharp.Client;
-using System.Linq;
-using System.Text.Json;
 
 namespace BrickOwlSharp.Demos
 {
@@ -46,8 +44,8 @@ namespace BrickOwlSharp.Demos
             Console.WriteLine($"Order {orderDetails.Id} has {orderDetails.Items.Count} items.");
 
             // Sample: retrieve tax scheme metadata.
-            JsonElement taxSchemes = await client.GetOrderTaxSchemesAsync();
-            Console.WriteLine($"Tax scheme payload has properties: {taxSchemes.EnumerateObject().Count()}");
+            OrderTaxSchemesResponse taxSchemes = await client.GetOrderTaxSchemesAsync();
+            Console.WriteLine($"Tax scheme payload has properties: {taxSchemes.AdditionalData.Count}");
 
             // Toggle write samples to avoid accidental mutations.
             bool runOrderUpdates = false;


### PR DESCRIPTION
### Motivation

- Reduce reliance on unstructured `JsonElement` responses and provide typed DTOs for clearer deserialization and stronger typing.
- Simplify request construction for batch and cart endpoints by accepting tuple-style inputs instead of requiring pre-serialized JSON payloads.
- Improve code organization by placing each response DTO in its own file for maintainability.
- Update sample/demo code to reflect the new signatures and typed responses.

### Description

- Replaced `Task<JsonElement>` return types with concrete DTOs such as `CatalogBulkResponse`, `CatalogSearchResponse`, `OrderTaxSchemesResponse`, `UserDetailsResponse`, and `InvoiceTransactionsResponse`, and added the corresponding response classes (one per file).
- Changed `BulkBatchAsync` to accept `IEnumerable<(string Endpoint, string RequestMethod, IEnumerable<Dictionary<string,string>> Parameters)>` and `CreateCatalogCartBasicAsync` to accept `IEnumerable<(string DesignId, int? ColorId, string Boid, int Quantity)>`, with internal serialization of the payloads.
- Updated `IBrickOwlClient` signatures and `BrickOwlClient` implementations to use the new DTO types and to call `ExecuteGet<T>`/`ExecutePost<T>` with the DTOs.
- Updated demo projects (`CatalogAdvancedDemo`, `InvoiceDemo`, `OrderManagementDemo`, `UserDemo`) to construct tuple inputs and consume the new typed responses.

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953fa97508c8330a8988e53f4f9a509)