### PR TITLE
Add per-method apiKey parameter and multi-store support

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -10,14 +10,16 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
- 
+
     steps:
     - uses: actions/checkout@v3
     - name: Setup .NET
       uses: actions/setup-dotnet@v2
       with:
-        dotnet-version: 6.0.x
-    - name: Restore library dependencies 
-      run: dotnet restore BrickOwlSharp.Client/BrickOwlSharp.Client.csproj
-    - name: Build library
-      run: dotnet build BrickOwlSharp.Client/BrickOwlSharp.Client.csproj --no-restore
+        dotnet-version: 10.0.x
+    - name: Restore dependencies
+      run: dotnet restore BrickOwlSharp.sln
+    - name: Build
+      run: dotnet build BrickOwlSharp.sln --no-restore
+    - name: Test
+      run: dotnet test BrickOwlSharp.Tests/BrickOwlSharp.Tests.csproj --no-build --verbosity normal

--- a/BrickOwlSharp.Client/BrickOwlClient.cs
+++ b/BrickOwlSharp.Client/BrickOwlClient.cs
@@ -150,14 +150,26 @@ namespace BrickOwlSharp.Client
         public async Task<OrderDetails> GetOrderAsync(int orderId, string apiKey = default, CancellationToken cancellationToken = default)
         {
             var detailsUrl = AppendOptionalParam(new Uri(_baseUri, "order/view").ToString(), "order_id", orderId);
-            var itemUrl    = AppendOptionalParam(new Uri(_baseUri, "order/items").ToString(), "order_id", orderId);
+            var itemUrl = AppendOptionalParam(new Uri(_baseUri, "order/items").ToString(), "order_id", orderId);
 
-            var detailsTask = ExecuteGet<OrderDetails>(detailsUrl, apiKey, cancellationToken);
-            var itemsTask   = ExecuteGet<List<OrderItem>>(itemUrl, apiKey, cancellationToken);
+            async Task<OrderDetails> FetchDetails()
+            {
+                var result = await ExecuteGet<OrderDetails>(detailsUrl, apiKey, cancellationToken);
+                _measureRequest(ResourceType.Order, cancellationToken);
+                return result;
+            }
+
+            async Task<List<OrderItem>> FetchItems()
+            {
+                var result = await ExecuteGet<List<OrderItem>>(itemUrl, apiKey, cancellationToken);
+                _measureRequest(ResourceType.Order, cancellationToken);
+                return result;
+            }
+
+            var detailsTask = FetchDetails();
+            var itemsTask = FetchItems();
 
             await Task.WhenAll(detailsTask, itemsTask);
-            _measureRequest(ResourceType.Order, cancellationToken);
-            _measureRequest(ResourceType.Order, cancellationToken);
 
             var details = detailsTask.Result;
             details.OrderItems = itemsTask.Result;
@@ -198,25 +210,25 @@ namespace BrickOwlSharp.Client
 
         public async Task<bool> UpdateOrderTrackingAsync(int orderId, string trackingIdOrUrl, string apiKey = default, CancellationToken cancellationToken = default)
         {
-        	Dictionary<string, string> formData = new Dictionary<string, string>
-        	{
-        		{ "order_id", orderId.ToString() },
-        		{ "tracking_id", trackingIdOrUrl },
-        		{ "key", ResolveApiKey(apiKey) }
-        	};
-        
-        	var url = new Uri(_baseUri, "order/tracking").ToString();
-        
-        	try
-        	{
-        		BrickOwlResult result = await ExecutePost<BrickOwlResult>(url, formData, cancellationToken: cancellationToken);
-        		_measureRequest(ResourceType.Order, cancellationToken);
-        		return string.Equals(result.Status, "success", StringComparison.OrdinalIgnoreCase);
-        	}
-        	catch
-        	{
-        		return false;
-        	}
+            Dictionary<string, string> formData = new Dictionary<string, string>
+            {
+                { "order_id", orderId.ToString() },
+                { "tracking_id", trackingIdOrUrl },
+                { "key", ResolveApiKey(apiKey) }
+            };
+
+            var url = new Uri(_baseUri, "order/tracking").ToString();
+
+            try
+            {
+                BrickOwlResult result = await ExecutePost<BrickOwlResult>(url, formData, cancellationToken: cancellationToken);
+                _measureRequest(ResourceType.Order, cancellationToken);
+                return string.Equals(result.Status, "success", StringComparison.OrdinalIgnoreCase);
+            }
+            catch
+            {
+                return false;
+            }
         } // !UpdateOrderTrackingAsync()
 
 
@@ -376,7 +388,7 @@ namespace BrickOwlSharp.Client
         } // !CreateCatalogCartBasicAsync()
 
 
-        public async Task<Dictionary<string,CatalogItemAvailability>> CatalogAvailabilityAsync(string boid, string country, int? quantity = null, string storeCountry = null, string apiKey = default, CancellationToken cancellationToken = default)
+        public async Task<Dictionary<string, CatalogItemAvailability>> CatalogAvailabilityAsync(string boid, string country, int? quantity = null, string storeCountry = null, string apiKey = default, CancellationToken cancellationToken = default)
         {
             var url = new Uri(_baseUri, $"catalog/availability").ToString();
             url = AppendOptionalParam(url, "boid", boid);
@@ -468,7 +480,7 @@ namespace BrickOwlSharp.Client
             url = AppendOptionalParam(url, "filter", filter);
 
             if (activeOnly.HasValue)
-            {               
+            {
                 url = AppendOptionalParam(url, "active_only", activeOnly.Value == true ? 1 : 0);
             }
 
@@ -694,7 +706,7 @@ namespace BrickOwlSharp.Client
             var responseData = JsonSerializer.Deserialize<TResponse>(contentAsString) ?? throw new Exception("");
             return responseData;
         } // !ExecuteGet()
-          
+
 
         private async Task<TResponse> ExecutePost<TResponse>(string url, Dictionary<string, string> formData, CancellationToken cancellationToken = default)
         {

--- a/BrickOwlSharp.Client/BrickOwlClient.cs
+++ b/BrickOwlSharp.Client/BrickOwlClient.cs
@@ -45,16 +45,19 @@ namespace BrickOwlSharp.Client
         private static readonly Uri _baseUri = new Uri("https://api.brickowl.com/v1/");
         private readonly HttpClient _httpClient;
         private readonly bool _disposeHttpClient;
+        private readonly string _defaultApiKey;
 
         private bool _isDisposed;
         private readonly IBrickOwlRequestHandler _requestHandler;
 
         public BrickOwlClient(HttpClient httpClient,
             bool disposeHttpClient,
+            string defaultApiKey = null,
             IBrickOwlRequestHandler requestHandler = null)
         {
             _httpClient = httpClient;
             _disposeHttpClient = disposeHttpClient;
+            _defaultApiKey = defaultApiKey;
             _requestHandler = requestHandler;
         }
 
@@ -146,16 +149,18 @@ namespace BrickOwlSharp.Client
 
         public async Task<OrderDetails> GetOrderAsync(int orderId, string apiKey = default, CancellationToken cancellationToken = default)
         {
-            var detailsUrl = new Uri(_baseUri, $"order/view").ToString();
-            detailsUrl = AppendOptionalParam(detailsUrl, "order_id", orderId);
-            OrderDetails details = await ExecuteGet<OrderDetails>(detailsUrl, apiKey, cancellationToken);
+            var detailsUrl = AppendOptionalParam(new Uri(_baseUri, "order/view").ToString(), "order_id", orderId);
+            var itemUrl    = AppendOptionalParam(new Uri(_baseUri, "order/items").ToString(), "order_id", orderId);
+
+            var detailsTask = ExecuteGet<OrderDetails>(detailsUrl, apiKey, cancellationToken);
+            var itemsTask   = ExecuteGet<List<OrderItem>>(itemUrl, apiKey, cancellationToken);
+
+            await Task.WhenAll(detailsTask, itemsTask);
+            _measureRequest(ResourceType.Order, cancellationToken);
             _measureRequest(ResourceType.Order, cancellationToken);
 
-            var itemUrl = new Uri(_baseUri, $"order/items").ToString();
-            itemUrl = AppendOptionalParam(itemUrl, "order_id", orderId);
-            List<OrderItem> items = await ExecuteGet<List<OrderItem>>(itemUrl, apiKey, cancellationToken);
-            _measureRequest(ResourceType.Order, cancellationToken);
-            details.OrderItems = items;
+            var details = detailsTask.Result;
+            details.OrderItems = itemsTask.Result;
             return details;
         } // !GetOrderAsync()
 
@@ -166,7 +171,7 @@ namespace BrickOwlSharp.Client
             {
                 { "order_id", orderId.ToString() },
                 { "status_id", ((int)status).ToString() },
-                { "key", apiKey ?? BrickOwlClientConfiguration.Instance.ApiKey }
+                { "key", ResolveApiKey(apiKey) }
             };
 
             var url = new Uri(_baseUri, $"order/set_status").ToString();
@@ -197,7 +202,7 @@ namespace BrickOwlSharp.Client
         	{
         		{ "order_id", orderId.ToString() },
         		{ "tracking_id", trackingIdOrUrl },
-        		{ "key", apiKey ?? BrickOwlClientConfiguration.Instance.ApiKey }
+        		{ "key", ResolveApiKey(apiKey) }
         	};
         
         	var url = new Uri(_baseUri, "order/tracking").ToString();
@@ -257,7 +262,7 @@ namespace BrickOwlSharp.Client
             Dictionary<string, string> formData = new Dictionary<string, string>()
             {
                 { "requests", requestsJson },
-                { "key", apiKey ?? BrickOwlClientConfiguration.Instance.ApiKey }
+                { "key", ResolveApiKey(apiKey) }
             };
 
             var url = new Uri(_baseUri, "bulk/batch").ToString();
@@ -361,7 +366,7 @@ namespace BrickOwlSharp.Client
                 { "items", itemsJson },
                 { "condition", condition },
                 { "country", country },
-                { "key", apiKey ?? BrickOwlClientConfiguration.Instance.ApiKey }
+                { "key", ResolveApiKey(apiKey) }
             };
 
             var url = new Uri(_baseUri, "catalog/cart_basic").ToString();
@@ -516,7 +521,7 @@ namespace BrickOwlSharp.Client
             {
                 { "order_id", orderId.ToString() },
                 { "note", note },
-                { "key", apiKey ?? BrickOwlClientConfiguration.Instance.ApiKey }
+                { "key", ResolveApiKey(apiKey) }
             };
 
             var url = new Uri(_baseUri, "order/note").ToString();
@@ -547,7 +552,7 @@ namespace BrickOwlSharp.Client
             Dictionary<string, string> formData = new Dictionary<string, string>()
             {
                 { "ip", ipAddress },
-                { "key", apiKey ?? BrickOwlClientConfiguration.Instance.ApiKey }
+                { "key", ResolveApiKey(apiKey) }
             };
 
             var url = new Uri(_baseUri, "order/notify").ToString();
@@ -610,7 +615,7 @@ namespace BrickOwlSharp.Client
                 { "order_id", orderId.ToString() },
                 { "rating", ((int)rating).ToString() },
                 { "comment", comment },
-                { "key", apiKey ?? BrickOwlClientConfiguration.Instance.ApiKey }
+                { "key", ResolveApiKey(apiKey) }
             };
 
             var url = new Uri(_baseUri, $"order/feedback").ToString();
@@ -635,10 +640,20 @@ namespace BrickOwlSharp.Client
         } // !LeaveFeedbackAsync()
 
 
-        private static string AppendApiKey(string url, string apiKey = null)
+        private string ResolveApiKey(string perCallKey)
         {
-            BrickOwlClientConfiguration.Instance.ValidateThrowException();
-            return AppendOptionalParam(url, "key", apiKey ?? BrickOwlClientConfiguration.Instance.ApiKey);
+            var key = perCallKey ?? _defaultApiKey ?? BrickOwlClientConfiguration.Instance.ApiKey;
+            if (string.IsNullOrEmpty(key))
+                throw new InvalidOperationException(
+                    "No API key configured. Set BrickOwlClientConfiguration.Instance.ApiKey, " +
+                    "pass apiKey to BrickOwlClientFactory.Build(), or pass apiKey directly to the method.");
+            return key;
+        } // !ResolveApiKey()
+
+
+        private string AppendApiKey(string url, string apiKey = null)
+        {
+            return AppendOptionalParam(url, "key", ResolveApiKey(apiKey));
         } // !AppendApiKey()
 
 
@@ -777,7 +792,7 @@ namespace BrickOwlSharp.Client
 
             if (addKey)
             {
-                result.Add("key", apiKey ?? BrickOwlClientConfiguration.Instance.ApiKey);
+                result.Add("key", ResolveApiKey(apiKey));
             }
 
             return result;

--- a/BrickOwlSharp.Client/BrickOwlClient.cs
+++ b/BrickOwlSharp.Client/BrickOwlClient.cs
@@ -101,6 +101,7 @@ namespace BrickOwlSharp.Client
             int? limit = null,
             OrderType? orderType = null,
             OrderSortType? orderSortType = null,
+            string apiKey = default,
             CancellationToken cancellationToken = default)
         {
             var url = new Uri(_baseUri, $"order/list").ToString();
@@ -137,35 +138,35 @@ namespace BrickOwlSharp.Client
                 url = AppendOptionalParam(url, "sort_by", orderSortType.Value.ToString().ToLower());
             }
 
-            List<Order> result = await ExecuteGet<List<Order>>(url, cancellationToken);
+            List<Order> result = await ExecuteGet<List<Order>>(url, apiKey, cancellationToken);
             _measureRequest(ResourceType.Order, cancellationToken);
             return result;
         } // !GetOrdersAsync()
 
 
-        public async Task<OrderDetails> GetOrderAsync(int orderId,  CancellationToken cancellationToken = default)
+        public async Task<OrderDetails> GetOrderAsync(int orderId, string apiKey = default, CancellationToken cancellationToken = default)
         {
             var detailsUrl = new Uri(_baseUri, $"order/view").ToString();
             detailsUrl = AppendOptionalParam(detailsUrl, "order_id", orderId);
-            OrderDetails details = await ExecuteGet<OrderDetails>(detailsUrl, cancellationToken);
+            OrderDetails details = await ExecuteGet<OrderDetails>(detailsUrl, apiKey, cancellationToken);
             _measureRequest(ResourceType.Order, cancellationToken);
 
             var itemUrl = new Uri(_baseUri, $"order/items").ToString();
             itemUrl = AppendOptionalParam(itemUrl, "order_id", orderId);
-            List<OrderItem> items = await ExecuteGet<List<OrderItem>>(itemUrl, cancellationToken);
+            List<OrderItem> items = await ExecuteGet<List<OrderItem>>(itemUrl, apiKey, cancellationToken);
             _measureRequest(ResourceType.Order, cancellationToken);
             details.OrderItems = items;
             return details;
         } // !GetOrderAsync()
 
 
-        public async Task<bool> UpdateOrderStatusAsync(int orderId, OrderStatus status, CancellationToken cancellationToken = default)
+        public async Task<bool> UpdateOrderStatusAsync(int orderId, OrderStatus status, string apiKey = default, CancellationToken cancellationToken = default)
         {
             Dictionary<string, string> formData = new Dictionary<string, string>()
             {
                 { "order_id", orderId.ToString() },
                 { "status_id", ((int)status).ToString() },
-                { "key", BrickOwlClientConfiguration.Instance.ApiKey }
+                { "key", apiKey ?? BrickOwlClientConfiguration.Instance.ApiKey }
             };
 
             var url = new Uri(_baseUri, $"order/set_status").ToString();
@@ -190,13 +191,13 @@ namespace BrickOwlSharp.Client
         } // !UpdateOrderStatusAsync()
 
 
-        public async Task<bool> UpdateOrderTrackingAsync(int orderId, string trackingIdOrUrl, CancellationToken cancellationToken = default)
+        public async Task<bool> UpdateOrderTrackingAsync(int orderId, string trackingIdOrUrl, string apiKey = default, CancellationToken cancellationToken = default)
         {
         	Dictionary<string, string> formData = new Dictionary<string, string>
         	{
         		{ "order_id", orderId.ToString() },
         		{ "tracking_id", trackingIdOrUrl },
-        		{ "key", BrickOwlClientConfiguration.Instance.ApiKey }
+        		{ "key", apiKey ?? BrickOwlClientConfiguration.Instance.ApiKey }
         	};
         
         	var url = new Uri(_baseUri, "order/tracking").ToString();
@@ -215,20 +216,22 @@ namespace BrickOwlSharp.Client
 
 
         public async Task<List<Wishlist>> GetWishlistsAsync(
+           string apiKey = default,
            CancellationToken cancellationToken = default)
         {
             var url = new Uri(_baseUri, $"wishlist/lists").ToString();
-            List<Wishlist> result = await ExecuteGet<List<Wishlist>>(url, cancellationToken);
+            List<Wishlist> result = await ExecuteGet<List<Wishlist>>(url, apiKey, cancellationToken);
             _measureRequest(ResourceType.Wishlist, cancellationToken);
             return result;
         } // !GetWishlistsAsync()
 
 
         public async Task<List<CatalogItem>> GetCatalogAsync(
+           string apiKey = default,
            CancellationToken cancellationToken = default)
         {
             var url = new Uri(_baseUri, $"catalog/list").ToString();
-            List<CatalogItem> result = await ExecuteGet<List<CatalogItem>>(url, cancellationToken);
+            List<CatalogItem> result = await ExecuteGet<List<CatalogItem>>(url, apiKey, cancellationToken);
             _measureRequest(ResourceType.Catalog, cancellationToken);
             return result;
         } // !GetCatalogAsync()
@@ -236,6 +239,7 @@ namespace BrickOwlSharp.Client
 
         public async Task<BulkBatchResponse> BulkBatchAsync(
             IEnumerable<(string Endpoint, string RequestMethod, IEnumerable<Dictionary<string, string>> Parameters)> requests,
+            string apiKey = default,
             CancellationToken cancellationToken = default)
         {
             var payload = new
@@ -253,7 +257,7 @@ namespace BrickOwlSharp.Client
             Dictionary<string, string> formData = new Dictionary<string, string>()
             {
                 { "requests", requestsJson },
-                { "key", BrickOwlClientConfiguration.Instance.ApiKey }
+                { "key", apiKey ?? BrickOwlClientConfiguration.Instance.ApiKey }
             };
 
             var url = new Uri(_baseUri, "bulk/batch").ToString();
@@ -263,53 +267,53 @@ namespace BrickOwlSharp.Client
         } // !BulkBatchAsync()
 
 
-        public async Task<CatalogBulkResponse> CatalogBulkAsync(string type, CancellationToken cancellationToken = default)
+        public async Task<CatalogBulkResponse> CatalogBulkAsync(string type, string apiKey = default, CancellationToken cancellationToken = default)
         {
             var url = new Uri(_baseUri, "catalog/bulk").ToString();
             url = AppendOptionalParam(url, "type", type);
-            CatalogBulkResponse result = await ExecuteGet<CatalogBulkResponse>(url, cancellationToken);
+            CatalogBulkResponse result = await ExecuteGet<CatalogBulkResponse>(url, apiKey, cancellationToken);
             _measureRequest(ResourceType.Catalog, cancellationToken);
             return result;
         } // !CatalogBulkAsync()
 
 
-        public async Task<CatalogBulkLookupResponse> CatalogBulkLookupAsync(IEnumerable<string> boids, CancellationToken cancellationToken = default)
+        public async Task<CatalogBulkLookupResponse> CatalogBulkLookupAsync(IEnumerable<string> boids, string apiKey = default, CancellationToken cancellationToken = default)
         {
             var url = new Uri(_baseUri, "catalog/bulk_lookup").ToString();
             url = AppendOptionalParam(url, "boids", string.Join(",", boids ?? Enumerable.Empty<string>()));
-            CatalogBulkLookupResponse result = await ExecuteGet<CatalogBulkLookupResponse>(url, cancellationToken);
+            CatalogBulkLookupResponse result = await ExecuteGet<CatalogBulkLookupResponse>(url, apiKey, cancellationToken);
             _measureRequest(ResourceType.Catalog, cancellationToken);
             return result;
         } // !CatalogBulkLookupAsync()
 
 
-        public async Task<CatalogSearchResponse> CatalogSearchAsync(string query, int? page = null, string missingData = null, CancellationToken cancellationToken = default)
+        public async Task<CatalogSearchResponse> CatalogSearchAsync(string query, int? page = null, string missingData = null, string apiKey = default, CancellationToken cancellationToken = default)
         {
             var url = new Uri(_baseUri, "catalog/search").ToString();
             url = AppendOptionalParam(url, "query", query);
             url = AppendOptionalParam(url, "page", page);
             url = AppendOptionalParam(url, "missing_data", missingData);
-            CatalogSearchResponse result = await ExecuteGet<CatalogSearchResponse>(url, cancellationToken);
+            CatalogSearchResponse result = await ExecuteGet<CatalogSearchResponse>(url, apiKey, cancellationToken);
             _measureRequest(ResourceType.Catalog, cancellationToken);
             return result;
         } // !CatalogSearchAsync()
 
 
-        public async Task<CatalogConditionListResponse> GetCatalogConditionListAsync(CancellationToken cancellationToken = default)
+        public async Task<CatalogConditionListResponse> GetCatalogConditionListAsync(string apiKey = default, CancellationToken cancellationToken = default)
         {
             var url = new Uri(_baseUri, "catalog/condition_list").ToString();
-            CatalogConditionListResponse result = await ExecuteGet<CatalogConditionListResponse>(url, cancellationToken);
+            CatalogConditionListResponse result = await ExecuteGet<CatalogConditionListResponse>(url, apiKey, cancellationToken);
             _measureRequest(ResourceType.Catalog, cancellationToken);
             return result;
         } // !GetCatalogConditionListAsync()
 
 
-        public async Task<CatalogFieldOptionListResponse> GetCatalogFieldOptionListAsync(string type, string language = null, CancellationToken cancellationToken = default)
+        public async Task<CatalogFieldOptionListResponse> GetCatalogFieldOptionListAsync(string type, string language = null, string apiKey = default, CancellationToken cancellationToken = default)
         {
             var url = new Uri(_baseUri, "catalog/field_option_list").ToString();
             url = AppendOptionalParam(url, "type", type);
             url = AppendOptionalParam(url, "language", language);
-            CatalogFieldOptionListResponse result = await ExecuteGet<CatalogFieldOptionListResponse>(url, cancellationToken);
+            CatalogFieldOptionListResponse result = await ExecuteGet<CatalogFieldOptionListResponse>(url, apiKey, cancellationToken);
             _measureRequest(ResourceType.Catalog, cancellationToken);
             return result;
         } // !GetCatalogFieldOptionListAsync()
@@ -318,6 +322,7 @@ namespace BrickOwlSharp.Client
             IEnumerable<(string DesignId, int? ColorId, string Boid, int Quantity)> items,
             string condition,
             string country,
+            string apiKey = default,
             CancellationToken cancellationToken = default)
         {
             var itemList = new List<Dictionary<string, string>>();
@@ -356,7 +361,7 @@ namespace BrickOwlSharp.Client
                 { "items", itemsJson },
                 { "condition", condition },
                 { "country", country },
-                { "key", BrickOwlClientConfiguration.Instance.ApiKey }
+                { "key", apiKey ?? BrickOwlClientConfiguration.Instance.ApiKey }
             };
 
             var url = new Uri(_baseUri, "catalog/cart_basic").ToString();
@@ -366,7 +371,7 @@ namespace BrickOwlSharp.Client
         } // !CreateCatalogCartBasicAsync()
 
 
-        public async Task<Dictionary<string,CatalogItemAvailability>> CatalogAvailabilityAsync(string boid, string country, int? quantity = null, string storeCountry = null, CancellationToken cancellationToken = default)
+        public async Task<Dictionary<string,CatalogItemAvailability>> CatalogAvailabilityAsync(string boid, string country, int? quantity = null, string storeCountry = null, string apiKey = default, CancellationToken cancellationToken = default)
         {
             var url = new Uri(_baseUri, $"catalog/availability").ToString();
             url = AppendOptionalParam(url, "boid", boid);
@@ -382,23 +387,23 @@ namespace BrickOwlSharp.Client
                 url = AppendOptionalParam(url, "store_country", storeCountry);
             }
 
-            Dictionary<string, CatalogItemAvailability> result = await ExecuteGet<Dictionary<string, CatalogItemAvailability>>(url, cancellationToken);
+            Dictionary<string, CatalogItemAvailability> result = await ExecuteGet<Dictionary<string, CatalogItemAvailability>>(url, apiKey, cancellationToken);
             _measureRequest(ResourceType.Catalog, cancellationToken);
             return result;
         } // !CatalogAvailabilityAsync()
 
 
-        public async Task<CatalogItem> CatalogLookupAsync(string boid, CancellationToken cancellationToken = default)
+        public async Task<CatalogItem> CatalogLookupAsync(string boid, string apiKey = default, CancellationToken cancellationToken = default)
         {
             var url = new Uri(_baseUri, $"catalog/lookup").ToString();
             url = AppendOptionalParam(url, "boid", boid);
-            CatalogItem result = await ExecuteGet<CatalogItem> (url, cancellationToken);
+            CatalogItem result = await ExecuteGet<CatalogItem>(url, apiKey, cancellationToken);
             _measureRequest(ResourceType.Catalog, cancellationToken);
             return result;
         } // !CatalogLookupAsync()
 
 
-        public async Task<List<string>> CatalogIdLookupAsync(string boid, ItemType type, IdType? idType = null, CancellationToken cancellationToken = default)
+        public async Task<List<string>> CatalogIdLookupAsync(string boid, ItemType type, IdType? idType = null, string apiKey = default, CancellationToken cancellationToken = default)
         {
             var url = new Uri(_baseUri, $"catalog/id_lookup").ToString();
             url = AppendOptionalParam(url, "id", boid);
@@ -409,7 +414,7 @@ namespace BrickOwlSharp.Client
                 url = AppendOptionalParam(url, "id_type", idType.Value.EnumToString());
             }
 
-            CatalogItemIds result = await ExecuteGet<CatalogItemIds>(url, cancellationToken);
+            CatalogItemIds result = await ExecuteGet<CatalogItemIds>(url, apiKey, cancellationToken);
             _measureRequest(ResourceType.Catalog, cancellationToken);
             return result.BOIDs;
         } // !CatalogIdLookupAsync()
@@ -417,9 +422,10 @@ namespace BrickOwlSharp.Client
 
         public async Task<NewInventoryResult> CreateInventoryAsync(
             NewInventory newInventory,
+            string apiKey = default,
             CancellationToken cancellationToken = default)
         {
-            Dictionary<string, string> formData = _ObjectToFormData(newInventory);
+            Dictionary<string, string> formData = _ObjectToFormData(newInventory, apiKey: apiKey);
 
             if (!newInventory.ColorId.HasValue)
             {
@@ -435,9 +441,10 @@ namespace BrickOwlSharp.Client
 
         public async Task<bool> UpdateInventoryAsync(
             UpdateInventory updatedInventory,
+            string apiKey = default,
             CancellationToken cancellationToken = default)
         {
-            Dictionary<string, string> formData = _ObjectToFormData(updatedInventory);
+            Dictionary<string, string> formData = _ObjectToFormData(updatedInventory, apiKey: apiKey);
 
             var url = new Uri(_baseUri, $"inventory/update").ToString();
             BrickOwlResult result = await ExecutePost<BrickOwlResult>(url, formData, cancellationToken: cancellationToken);
@@ -448,6 +455,7 @@ namespace BrickOwlSharp.Client
 
         public async Task<List<Inventory>> GetInventoryAsync(
             string filter = null, bool? activeOnly = null, string externalId = null, int? lotId = null,
+            string apiKey = default,
             CancellationToken cancellationToken = default)
         {
             var url = new Uri(_baseUri, $"inventory/list").ToString();
@@ -462,7 +470,7 @@ namespace BrickOwlSharp.Client
             url = AppendOptionalParam(url, "external_id_1", externalId);
             url = AppendOptionalParam(url, "lot_id", lotId);
 
-            List<Inventory> result = await ExecuteGet<List<Inventory>>(url, cancellationToken);
+            List<Inventory> result = await ExecuteGet<List<Inventory>>(url, apiKey, cancellationToken);
             _measureRequest(ResourceType.Inventory, cancellationToken);
             return result;
         } // !GetInventoryAsync()
@@ -470,9 +478,10 @@ namespace BrickOwlSharp.Client
 
         public async Task<bool> DeleteInventoryAsync(
            DeleteInventory deleteInventory,
+           string apiKey = default,
            CancellationToken cancellationToken = default)
         {
-            Dictionary<string, string> formData = _ObjectToFormData(deleteInventory);            
+            Dictionary<string, string> formData = _ObjectToFormData(deleteInventory, apiKey: apiKey);
 
             var url = new Uri(_baseUri, $"inventory/delete").ToString();
             BrickOwlResult result = await ExecutePost<BrickOwlResult>(url, formData, cancellationToken: cancellationToken);
@@ -481,33 +490,33 @@ namespace BrickOwlSharp.Client
         } // !GetInventoryAsync()
 
 
-        public async Task<List<Color>> GetColorListAsyn(CancellationToken cancellationToken = default)
+        public async Task<List<Color>> GetColorListAsyn(string apiKey = default, CancellationToken cancellationToken = default)
         {
             var url = new Uri(_baseUri, $"catalog/color_list").ToString();
 
-            Dictionary<string, Color> result = await ExecuteGet<Dictionary<string, Color>>(url, cancellationToken);
+            Dictionary<string, Color> result = await ExecuteGet<Dictionary<string, Color>>(url, apiKey, cancellationToken);
             _measureRequest(ResourceType.Catalog, cancellationToken);
             return result.Values.ToList();
         } // !GetColorListAsyn()
 
 
-        public async Task<List<ItemInventoryItem>> GetItemInventoryAsync(string boid, CancellationToken cancellationToken = default)
+        public async Task<List<ItemInventoryItem>> GetItemInventoryAsync(string boid, string apiKey = default, CancellationToken cancellationToken = default)
         {
             var url = new Uri(_baseUri, $"catalog/inventory").ToString();
             url = AppendOptionalParam(url, "boid", boid);
 
-            ItemInventoryItemCollection result = await ExecuteGet<ItemInventoryItemCollection>(url, cancellationToken);
+            ItemInventoryItemCollection result = await ExecuteGet<ItemInventoryItemCollection>(url, apiKey, cancellationToken);
             _measureRequest(ResourceType.Catalog, cancellationToken);
             return result?.Items;
         } // !GetItemInventoryAsync()
 
-        public async Task<bool> UpdateOrderNoteAsync(int orderId, string note, CancellationToken cancellationToken = default)
+        public async Task<bool> UpdateOrderNoteAsync(int orderId, string note, string apiKey = default, CancellationToken cancellationToken = default)
         {
             Dictionary<string, string> formData = new Dictionary<string, string>()
             {
                 { "order_id", orderId.ToString() },
                 { "note", note },
-                { "key", BrickOwlClientConfiguration.Instance.ApiKey }
+                { "key", apiKey ?? BrickOwlClientConfiguration.Instance.ApiKey }
             };
 
             var url = new Uri(_baseUri, "order/note").ToString();
@@ -525,20 +534,20 @@ namespace BrickOwlSharp.Client
         } // !UpdateOrderNoteAsync()
 
 
-        public async Task<OrderTaxSchemesResponse> GetOrderTaxSchemesAsync(CancellationToken cancellationToken = default)
+        public async Task<OrderTaxSchemesResponse> GetOrderTaxSchemesAsync(string apiKey = default, CancellationToken cancellationToken = default)
         {
             var url = new Uri(_baseUri, "order/tax_schemes").ToString();
-            OrderTaxSchemesResponse result = await ExecuteGet<OrderTaxSchemesResponse>(url, cancellationToken);
+            OrderTaxSchemesResponse result = await ExecuteGet<OrderTaxSchemesResponse>(url, apiKey, cancellationToken);
             _measureRequest(ResourceType.Order, cancellationToken);
             return result;
         } // !GetOrderTaxSchemesAsync()
 
-        public async Task<bool> SetOrderNotifyAsync(string ipAddress, CancellationToken cancellationToken = default)
+        public async Task<bool> SetOrderNotifyAsync(string ipAddress, string apiKey = default, CancellationToken cancellationToken = default)
         {
             Dictionary<string, string> formData = new Dictionary<string, string>()
             {
                 { "ip", ipAddress },
-                { "key", BrickOwlClientConfiguration.Instance.ApiKey }
+                { "key", apiKey ?? BrickOwlClientConfiguration.Instance.ApiKey }
             };
 
             var url = new Uri(_baseUri, "order/notify").ToString();
@@ -556,52 +565,52 @@ namespace BrickOwlSharp.Client
         }  // !SetOrderNotifyAsync()
 
 
-        public async Task<UserDetailsResponse> GetUserDetailsAsync(CancellationToken cancellationToken = default)
+        public async Task<UserDetailsResponse> GetUserDetailsAsync(string apiKey = default, CancellationToken cancellationToken = default)
         {
             var url = new Uri(_baseUri, "user/details").ToString();
-            UserDetailsResponse result = await ExecuteGet<UserDetailsResponse>(url, cancellationToken);
+            UserDetailsResponse result = await ExecuteGet<UserDetailsResponse>(url, apiKey, cancellationToken);
             _measureRequest(ResourceType.Unknown, cancellationToken);
             return result;
         } // !GetUserDetailsAsync()
 
 
-        public async Task<UserAddressesResponse> GetUserAddressesAsync(CancellationToken cancellationToken = default)
+        public async Task<UserAddressesResponse> GetUserAddressesAsync(string apiKey = default, CancellationToken cancellationToken = default)
         {
             var url = new Uri(_baseUri, "user/addresses").ToString();
-            UserAddressesResponse result = await ExecuteGet<UserAddressesResponse>(url, cancellationToken);
+            UserAddressesResponse result = await ExecuteGet<UserAddressesResponse>(url, apiKey, cancellationToken);
             _measureRequest(ResourceType.Unknown, cancellationToken);
             return result;
         } // !GetUserAddressesAsync()
 
 
-        public async Task<TokenDetailsResponse> GetTokenDetailsAsync(CancellationToken cancellationToken = default)
+        public async Task<TokenDetailsResponse> GetTokenDetailsAsync(string apiKey = default, CancellationToken cancellationToken = default)
         {
             var url = new Uri(_baseUri, "token/details").ToString();
-            TokenDetailsResponse result = await ExecuteGet<TokenDetailsResponse>(url, cancellationToken);
+            TokenDetailsResponse result = await ExecuteGet<TokenDetailsResponse>(url, apiKey, cancellationToken);
             _measureRequest(ResourceType.Unknown, cancellationToken);
             return result;
         } // !GetTokenDetailsAsync()
 
 
-        public async Task<InvoiceTransactionsResponse> GetInvoiceTransactionsAsync(string invoiceId, string idType, CancellationToken cancellationToken = default)
+        public async Task<InvoiceTransactionsResponse> GetInvoiceTransactionsAsync(string invoiceId, string idType, string apiKey = default, CancellationToken cancellationToken = default)
         {
             var url = new Uri(_baseUri, "invoice/transactions").ToString();
             url = AppendOptionalParam(url, "invoice_id", invoiceId);
             url = AppendOptionalParam(url, "id_type", idType);
-            InvoiceTransactionsResponse result = await ExecuteGet<InvoiceTransactionsResponse>(url, cancellationToken);
+            InvoiceTransactionsResponse result = await ExecuteGet<InvoiceTransactionsResponse>(url, apiKey, cancellationToken);
             _measureRequest(ResourceType.Unknown, cancellationToken);
             return result;
         } // !GetInvoiceTransactionsAsync()
 
 
-        public async Task<bool> LeaveFeedbackAsync(int orderId, FeedbackRating rating, string comment = null, CancellationToken cancellationToken = default)
+        public async Task<bool> LeaveFeedbackAsync(int orderId, FeedbackRating rating, string comment = null, string apiKey = default, CancellationToken cancellationToken = default)
         {
             Dictionary<string, string> formData = new Dictionary<string, string>()
             {
                 { "order_id", orderId.ToString() },
                 { "rating", ((int)rating).ToString() },
                 { "comment", comment },
-                { "key", BrickOwlClientConfiguration.Instance.ApiKey }
+                { "key", apiKey ?? BrickOwlClientConfiguration.Instance.ApiKey }
             };
 
             var url = new Uri(_baseUri, $"order/feedback").ToString();
@@ -626,10 +635,10 @@ namespace BrickOwlSharp.Client
         } // !LeaveFeedbackAsync()
 
 
-        private static string AppendApiKey(string url)
+        private static string AppendApiKey(string url, string apiKey = null)
         {
             BrickOwlClientConfiguration.Instance.ValidateThrowException();
-            return AppendOptionalParam(url, "key", BrickOwlClientConfiguration.Instance.ApiKey);
+            return AppendOptionalParam(url, "key", apiKey ?? BrickOwlClientConfiguration.Instance.ApiKey);
         } // !AppendApiKey()
 
 
@@ -648,9 +657,9 @@ namespace BrickOwlSharp.Client
         } // !AppendOptionalParam()
 
 
-        private async Task<TResponse> ExecuteGet<TResponse>(string url, CancellationToken cancellationToken = default)
+        private async Task<TResponse> ExecuteGet<TResponse>(string url, string apiKey = null, CancellationToken cancellationToken = default)
         {
-            var urlWithKey = AppendApiKey(url);
+            var urlWithKey = AppendApiKey(url, apiKey);
 
             using var message = new HttpRequestMessage(HttpMethod.Get, urlWithKey);
 
@@ -716,7 +725,7 @@ namespace BrickOwlSharp.Client
         } // !ExecutePost()
 
 
-        private Dictionary<string, string> _ObjectToFormData(object o, bool addKey = true)
+        private Dictionary<string, string> _ObjectToFormData(object o, bool addKey = true, string apiKey = null)
         {
             Dictionary<string, string> result = new Dictionary<string, string>();
 
@@ -768,7 +777,7 @@ namespace BrickOwlSharp.Client
 
             if (addKey)
             {
-                result.Add("key", BrickOwlClientConfiguration.Instance.ApiKey);
+                result.Add("key", apiKey ?? BrickOwlClientConfiguration.Instance.ApiKey);
             }
 
             return result;

--- a/BrickOwlSharp.Client/BrickOwlClientConfiguration.cs
+++ b/BrickOwlSharp.Client/BrickOwlClientConfiguration.cs
@@ -45,9 +45,5 @@ namespace BrickOwlSharp.Client
         {
         }
 
-
-        internal void ValidateThrowException()
-        {
-        }
     }
 }

--- a/BrickOwlSharp.Client/BrickOwlClientConfiguration.cs
+++ b/BrickOwlSharp.Client/BrickOwlClientConfiguration.cs
@@ -35,18 +35,10 @@ namespace BrickOwlSharp.Client
         public string ApiKey { get; set; }
 
 
-        private static BrickOwlClientConfiguration _instance;
-        public static BrickOwlClientConfiguration Instance
-        {
-            get
-            {
-                if (BrickOwlClientConfiguration._instance is null)
-                {
-                    BrickOwlClientConfiguration._instance = new BrickOwlClientConfiguration();
-                }
-                return _instance;
-            }
-        }
+        private static readonly Lazy<BrickOwlClientConfiguration> _lazy =
+            new Lazy<BrickOwlClientConfiguration>(() => new BrickOwlClientConfiguration());
+
+        public static BrickOwlClientConfiguration Instance => _lazy.Value;
 
 
         private BrickOwlClientConfiguration()

--- a/BrickOwlSharp.Client/BrickOwlClientFactory.cs
+++ b/BrickOwlSharp.Client/BrickOwlClientFactory.cs
@@ -33,16 +33,16 @@ namespace BrickOwlSharp.Client
 {
     public static class BrickOwlClientFactory
     {
-        private static IBrickOwlClient Build(HttpClient httpClient, bool disposeHttpClient, IBrickOwlRequestHandler requestHandler = null)
+        private static IBrickOwlClient Build(HttpClient httpClient, bool disposeHttpClient, string apiKey = null, IBrickOwlRequestHandler requestHandler = null)
         {
-            return new BrickOwlClient(httpClient, disposeHttpClient, requestHandler);
+            return new BrickOwlClient(httpClient, disposeHttpClient, apiKey, requestHandler);
         }
 
-        public static IBrickOwlClient Build(HttpClient httpClient = null, IBrickOwlRequestHandler requestHandler = null)
+        public static IBrickOwlClient Build(HttpClient httpClient = null, string apiKey = null, IBrickOwlRequestHandler requestHandler = null)
         {
             HttpClient _httpClient = null;
             bool _disposeHttpClient = false;
-            
+
             if (httpClient is null)
             {
                 _httpClient = new HttpClient();
@@ -52,9 +52,9 @@ namespace BrickOwlSharp.Client
             {
                 _httpClient = httpClient;
                 _disposeHttpClient = false;
-            }            
+            }
 
-            return Build(_httpClient, _disposeHttpClient, requestHandler);
+            return Build(_httpClient, _disposeHttpClient, apiKey, requestHandler);
         }
 
         public static IBrickOwlClient Build()

--- a/BrickOwlSharp.Client/IBrickOwlClient.cs
+++ b/BrickOwlSharp.Client/IBrickOwlClient.cs
@@ -61,6 +61,7 @@ namespace BrickOwlSharp.Client
             int? limit = null,
             OrderType? orderType = null,
             OrderSortType? orderSortType = null,
+            string apiKey = default,
             CancellationToken cancellationToken = default);
 
         /// <summary>
@@ -69,7 +70,7 @@ namespace BrickOwlSharp.Client
         /// <param name="orderId">Order ID.</param>
         /// <param name="cancellationToken">Token to cancel the request.</param>
         /// <returns>Order details and item list.</returns>
-        public Task<OrderDetails> GetOrderAsync(int orderId, CancellationToken cancellationToken = default);
+        public Task<OrderDetails> GetOrderAsync(int orderId, string apiKey = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Change the status of an order.
@@ -78,7 +79,7 @@ namespace BrickOwlSharp.Client
         /// <param name="status">New status.</param>
         /// <param name="cancellationToken">Token to cancel the request.</param>
         /// <returns>True if the update succeeded.</returns>
-        public Task<bool> UpdateOrderStatusAsync(int orderId, OrderStatus status, CancellationToken cancellationToken = default);
+        public Task<bool> UpdateOrderStatusAsync(int orderId, OrderStatus status, string apiKey = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Attach tracking information to an order.
@@ -87,21 +88,21 @@ namespace BrickOwlSharp.Client
         /// <param name="trackingIdOrUrl">Tracking ID or URL.</param>
         /// <param name="cancellationToken">Token to cancel the request.</param>
         /// <returns>True if the update succeeded.</returns>
-        public Task<bool> UpdateOrderTrackingAsync(int orderId, string trackingIdOrUrl, CancellationToken cancellationToken = default);
+        public Task<bool> UpdateOrderTrackingAsync(int orderId, string trackingIdOrUrl, string apiKey = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieve the wishlists available on the account.
         /// </summary>
         /// <param name="cancellationToken">Token to cancel the request.</param>
         /// <returns>List of wishlists.</returns>
-        public Task<List<Wishlist>> GetWishlistsAsync(CancellationToken cancellationToken = default);
+        public Task<List<Wishlist>> GetWishlistsAsync(string apiKey = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieve the full catalog list.
         /// </summary>
         /// <param name="cancellationToken">Token to cancel the request.</param>
         /// <returns>List of catalog items.</returns>
-        public Task<List<CatalogItem>> GetCatalogAsync(CancellationToken cancellationToken = default);
+        public Task<List<CatalogItem>> GetCatalogAsync(string apiKey = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Batch up to 50 requests into a single API call to reduce overhead.
@@ -113,6 +114,7 @@ namespace BrickOwlSharp.Client
         /// <returns>Batch response details.</returns>
         public Task<BulkBatchResponse> BulkBatchAsync(
             IEnumerable<(string Endpoint, string RequestMethod, IEnumerable<Dictionary<string, string>> Parameters)> requests,
+            string apiKey = default,
             CancellationToken cancellationToken = default);
 
         /// <summary>
@@ -121,7 +123,7 @@ namespace BrickOwlSharp.Client
         /// <param name="type">Bulk type identifier.</param>
         /// <param name="cancellationToken">Token to cancel the request.</param>
         /// <returns>Bulk catalog response details.</returns>
-        public Task<CatalogBulkResponse> CatalogBulkAsync(string type, CancellationToken cancellationToken = default);
+        public Task<CatalogBulkResponse> CatalogBulkAsync(string type, string apiKey = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieve details about multiple catalog items at once.
@@ -129,7 +131,7 @@ namespace BrickOwlSharp.Client
         /// <param name="boids">A comma-separated list of BOIDs (maximum 100).</param>
         /// <param name="cancellationToken">Token to cancel the request.</param>
         /// <returns>Catalog bulk lookup response details.</returns>
-        public Task<CatalogBulkLookupResponse> CatalogBulkLookupAsync(IEnumerable<string> boids, CancellationToken cancellationToken = default);
+        public Task<CatalogBulkLookupResponse> CatalogBulkLookupAsync(IEnumerable<string> boids, string apiKey = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Search, browse, and filter the catalog.
@@ -139,14 +141,14 @@ namespace BrickOwlSharp.Client
         /// <param name="missingData">Optional missing data filter.</param>
         /// <param name="cancellationToken">Token to cancel the request.</param>
         /// <returns>Catalog search response details.</returns>
-        public Task<CatalogSearchResponse> CatalogSearchAsync(string query, int? page = null, string missingData = null, CancellationToken cancellationToken = default);
+        public Task<CatalogSearchResponse> CatalogSearchAsync(string query, int? page = null, string missingData = null, string apiKey = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieve a list of lot conditions supported by the catalog.
         /// </summary>
         /// <param name="cancellationToken">Token to cancel the request.</param>
         /// <returns>Catalog condition list response details.</returns>
-        public Task<CatalogConditionListResponse> GetCatalogConditionListAsync(CancellationToken cancellationToken = default);
+        public Task<CatalogConditionListResponse> GetCatalogConditionListAsync(string apiKey = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieve a list of options for a given catalog field.
@@ -155,7 +157,7 @@ namespace BrickOwlSharp.Client
         /// <param name="language">Optional language code.</param>
         /// <param name="cancellationToken">Token to cancel the request.</param>
         /// <returns>Catalog field option list response details.</returns>
-        public Task<CatalogFieldOptionListResponse> GetCatalogFieldOptionListAsync(string type, string language = null, CancellationToken cancellationToken = default);
+        public Task<CatalogFieldOptionListResponse> GetCatalogFieldOptionListAsync(string type, string language = null, string apiKey = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Create a basic catalog cart and return pricing information.
@@ -169,6 +171,7 @@ namespace BrickOwlSharp.Client
             IEnumerable<(string DesignId, int? ColorId, string Boid, int Quantity)> items,
             string condition,
             string country,
+            string apiKey = default,
             CancellationToken cancellationToken = default);
 
         /// <summary>
@@ -180,7 +183,7 @@ namespace BrickOwlSharp.Client
         /// <param name="storeCountry">Optional store country code.</param>
         /// <param name="cancellationToken">Token to cancel the request.</param>
         /// <returns>Availability information keyed by store ID.</returns>
-        public Task<Dictionary<string, CatalogItemAvailability>> CatalogAvailabilityAsync(string boid, string country, int? quantity = null, string storeCountry = null, CancellationToken cancellationToken = default);
+        public Task<Dictionary<string, CatalogItemAvailability>> CatalogAvailabilityAsync(string boid, string country, int? quantity = null, string storeCountry = null, string apiKey = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieve catalog details for a single BOID.
@@ -188,7 +191,7 @@ namespace BrickOwlSharp.Client
         /// <param name="boid">BOID of the item.</param>
         /// <param name="cancellationToken">Token to cancel the request.</param>
         /// <returns>Catalog item details.</returns>
-        public Task<CatalogItem> CatalogLookupAsync(string boid, CancellationToken cancellationToken = default);
+        public Task<CatalogItem> CatalogLookupAsync(string boid, string apiKey = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieve possible BOIDs for a given external ID.
@@ -198,7 +201,7 @@ namespace BrickOwlSharp.Client
         /// <param name="idType">Optional ID type filter.</param>
         /// <param name="cancellationToken">Token to cancel the request.</param>
         /// <returns>List of matching BOIDs.</returns>
-        public Task<List<string>> CatalogIdLookupAsync(string boid, ItemType type, IdType? idType = null, CancellationToken cancellationToken = default);
+        public Task<List<string>> CatalogIdLookupAsync(string boid, ItemType type, IdType? idType = null, string apiKey = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Create a new lot in store inventory.
@@ -206,7 +209,7 @@ namespace BrickOwlSharp.Client
         /// <param name="newInventory">New inventory details.</param>
         /// <param name="cancellationToken">Token to cancel the request.</param>
         /// <returns>Result containing the new lot ID.</returns>
-        public Task<NewInventoryResult> CreateInventoryAsync(NewInventory newInventory, CancellationToken cancellationToken = default);
+        public Task<NewInventoryResult> CreateInventoryAsync(NewInventory newInventory, string apiKey = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Update an existing inventory lot.
@@ -216,6 +219,7 @@ namespace BrickOwlSharp.Client
         /// <returns>True if the update succeeded.</returns>
         public Task<bool> UpdateInventoryAsync(
             UpdateInventory updatedInventory,
+            string apiKey = default,
             CancellationToken cancellationToken = default);
 
         /// <summary>
@@ -229,6 +233,7 @@ namespace BrickOwlSharp.Client
         /// <returns>List of inventory lots.</returns>
         public Task<List<Inventory>> GetInventoryAsync(
             string filter = null, bool? activeOnly = null, string externalId = null, int? lotId = null,
+            string apiKey = default,
             CancellationToken cancellationToken = default);
 
         /// <summary>
@@ -239,6 +244,7 @@ namespace BrickOwlSharp.Client
         /// <returns>True if the deletion succeeded.</returns>
         public Task<bool> DeleteInventoryAsync(
            DeleteInventory deleteInventory,
+           string apiKey = default,
            CancellationToken cancellationToken = default);
 
         /// <summary>
@@ -246,7 +252,7 @@ namespace BrickOwlSharp.Client
         /// </summary>
         /// <param name="cancellationToken">Token to cancel the request.</param>
         /// <returns>List of colors.</returns>
-        public Task<List<Color>> GetColorListAsyn(CancellationToken cancellationToken = default);
+        public Task<List<Color>> GetColorListAsyn(string apiKey = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Returns the item inventory for a given BOID. If you are passing the BOID of a set, the response
@@ -255,7 +261,7 @@ namespace BrickOwlSharp.Client
         /// <param name="boid">BOID of the item, e.g. the set</param>
         /// <param name="cancellationToken">Token to cancel the request.</param>
         /// <returns>Inventory items included in the item</returns>
-        public Task<List<ItemInventoryItem>> GetItemInventoryAsync(string boid, CancellationToken cancellationToken = default);
+        public Task<List<ItemInventoryItem>> GetItemInventoryAsync(string boid, string apiKey = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Update the seller note on an order.
@@ -264,14 +270,14 @@ namespace BrickOwlSharp.Client
         /// <param name="note">Seller note text.</param>
         /// <param name="cancellationToken">Token to cancel the request.</param>
         /// <returns>True if the update succeeded.</returns>
-        public Task<bool> UpdateOrderNoteAsync(int orderId, string note, CancellationToken cancellationToken = default);
+        public Task<bool> UpdateOrderNoteAsync(int orderId, string note, string apiKey = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieve tax schemes that can be applied to orders.
         /// </summary>
         /// <param name="cancellationToken">Token to cancel the request.</param>
         /// <returns>Raw JSON response from the API.</returns>
-        public Task<OrderTaxSchemesResponse> GetOrderTaxSchemesAsync(CancellationToken cancellationToken = default);
+        public Task<OrderTaxSchemesResponse> GetOrderTaxSchemesAsync(string apiKey = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Register or remove an IP address for order notifications.
@@ -281,28 +287,28 @@ namespace BrickOwlSharp.Client
         /// </param>
         /// <param name="cancellationToken">Token to cancel the request.</param>
         /// <returns>True if the update succeeded.</returns>
-        public Task<bool> SetOrderNotifyAsync(string ipAddress, CancellationToken cancellationToken = default);
+        public Task<bool> SetOrderNotifyAsync(string ipAddress, string apiKey = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieve details for the user associated with the API key.
         /// </summary>
         /// <param name="cancellationToken">Token to cancel the request.</param>
         /// <returns>Raw JSON response from the API.</returns>
-        public Task<UserDetailsResponse> GetUserDetailsAsync(CancellationToken cancellationToken = default);
+        public Task<UserDetailsResponse> GetUserDetailsAsync(string apiKey = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieve the addresses associated with the user account.
         /// </summary>
         /// <param name="cancellationToken">Token to cancel the request.</param>
         /// <returns>Raw JSON response from the API.</returns>
-        public Task<UserAddressesResponse> GetUserAddressesAsync(CancellationToken cancellationToken = default);
+        public Task<UserAddressesResponse> GetUserAddressesAsync(string apiKey = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieve details for the API key owner (deprecated endpoint).
         /// </summary>
         /// <param name="cancellationToken">Token to cancel the request.</param>
         /// <returns>Raw JSON response from the API.</returns>
-        public Task<TokenDetailsResponse> GetTokenDetailsAsync(CancellationToken cancellationToken = default);
+        public Task<TokenDetailsResponse> GetTokenDetailsAsync(string apiKey = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieve invoice transactions.
@@ -311,7 +317,7 @@ namespace BrickOwlSharp.Client
         /// <param name="idType">Invoice ID type (e.g. public_invoice_id or stripe_charge_id).</param>
         /// <param name="cancellationToken">Token to cancel the request.</param>
         /// <returns>Raw JSON response from the API.</returns>
-        public Task<InvoiceTransactionsResponse> GetInvoiceTransactionsAsync(string invoiceId, string idType, CancellationToken cancellationToken = default);
+        public Task<InvoiceTransactionsResponse> GetInvoiceTransactionsAsync(string invoiceId, string idType, string apiKey = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Leave feedback for an order.
@@ -321,6 +327,6 @@ namespace BrickOwlSharp.Client
         /// <param name="comment">Optional feedback comment.</param>
         /// <param name="cancellationToken">Token to cancel the request.</param>
         /// <returns>True if the feedback was accepted.</returns>
-        public Task<bool> LeaveFeedbackAsync(int orderId , FeedbackRating rating, string comment = null, CancellationToken cancellationToken = default);
+        public Task<bool> LeaveFeedbackAsync(int orderId, FeedbackRating rating, string comment = null, string apiKey = default, CancellationToken cancellationToken = default);
     }       
 }

--- a/BrickOwlSharp.Tests/BrickOwlClientApiKeyTests.cs
+++ b/BrickOwlSharp.Tests/BrickOwlClientApiKeyTests.cs
@@ -1,3 +1,27 @@
+#region License
+// Copyright (c) 2024 Stephan Stapel
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+# endregion
 using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;

--- a/BrickOwlSharp.Tests/BrickOwlClientApiKeyTests.cs
+++ b/BrickOwlSharp.Tests/BrickOwlClientApiKeyTests.cs
@@ -1,0 +1,139 @@
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using BrickOwlSharp.Client;
+using Xunit;
+
+namespace BrickOwlSharp.Tests;
+
+public class BrickOwlClientApiKeyTests
+{
+    private sealed class CapturingHandler : HttpMessageHandler
+    {
+        public string? CapturedUrl { get; private set; }
+        public string? CapturedBody { get; private set; }
+        private readonly string _responseJson;
+
+        public CapturingHandler(string responseJson)
+        {
+            _responseJson = responseJson;
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            CapturedUrl = request.RequestUri?.ToString();
+            if (request.Content != null)
+                CapturedBody = await request.Content.ReadAsStringAsync();
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(_responseJson)
+            };
+        }
+    }
+
+    private sealed class TrackingHandler : HttpMessageHandler
+    {
+        public List<string> CapturedUrls { get; } = new();
+        private readonly Func<string, string> _responseSelector;
+
+        public TrackingHandler(Func<string, string> responseSelector)
+        {
+            _responseSelector = responseSelector;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var url = request.RequestUri?.ToString() ?? string.Empty;
+            CapturedUrls.Add(url);
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(_responseSelector(url))
+            });
+        }
+    }
+
+    private static (IBrickOwlClient client, CapturingHandler handler) BuildClient(string responseJson)
+    {
+        var handler = new CapturingHandler(responseJson);
+        var client = BrickOwlClientFactory.Build(new HttpClient(handler));
+        return (client, handler);
+    }
+
+    [Fact]
+    public async Task GetOrdersAsync_WithoutApiKey_UsesInstanceApiKey()
+    {
+        BrickOwlClientConfiguration.Instance.ApiKey = "instance-key";
+        var (client, handler) = BuildClient("[]");
+
+        await client.GetOrdersAsync();
+
+        Assert.Contains("key=instance-key", handler.CapturedUrl);
+    }
+
+    [Fact]
+    public async Task GetOrdersAsync_WithExplicitApiKey_UsesExplicitKey()
+    {
+        BrickOwlClientConfiguration.Instance.ApiKey = "instance-key";
+        var (client, handler) = BuildClient("[]");
+
+        await client.GetOrdersAsync(apiKey: "explicit-key");
+
+        Assert.Contains("key=explicit-key", handler.CapturedUrl);
+        Assert.DoesNotContain("key=instance-key", handler.CapturedUrl);
+    }
+
+    [Fact]
+    public async Task GetOrderAsync_WithExplicitApiKey_UsesSameKeyForBothRequests()
+    {
+        BrickOwlClientConfiguration.Instance.ApiKey = "instance-key";
+        var trackingHandler = new TrackingHandler(url =>
+            url.Contains("order/items") ? "[]" : "{}");
+        var client = BrickOwlClientFactory.Build(new HttpClient(trackingHandler));
+
+        await client.GetOrderAsync(42, apiKey: "shop-key");
+
+        Assert.Equal(2, trackingHandler.CapturedUrls.Count);
+        foreach (var url in trackingHandler.CapturedUrls)
+        {
+            Assert.Contains("key=shop-key", url);
+            Assert.DoesNotContain("key=instance-key", url);
+        }
+    }
+
+    [Fact]
+    public async Task UpdateOrderStatusAsync_WithoutApiKey_UsesInstanceApiKeyInFormData()
+    {
+        BrickOwlClientConfiguration.Instance.ApiKey = "instance-key";
+        var (client, handler) = BuildClient("{\"status\":\"success\"}");
+
+        await client.UpdateOrderStatusAsync(1, OrderStatus.Processing);
+
+        Assert.Contains("key=instance-key", handler.CapturedBody);
+    }
+
+    [Fact]
+    public async Task UpdateOrderStatusAsync_WithExplicitApiKey_UsesExplicitKeyInFormData()
+    {
+        BrickOwlClientConfiguration.Instance.ApiKey = "instance-key";
+        var (client, handler) = BuildClient("{\"status\":\"success\"}");
+
+        await client.UpdateOrderStatusAsync(1, OrderStatus.Processing, apiKey: "shop2-key");
+
+        Assert.Contains("key=shop2-key", handler.CapturedBody);
+        Assert.DoesNotContain("key=instance-key", handler.CapturedBody);
+    }
+
+    [Fact]
+    public async Task UpdateOrderNoteAsync_WithExplicitApiKey_UsesExplicitKeyInFormData()
+    {
+        BrickOwlClientConfiguration.Instance.ApiKey = "instance-key";
+        var (client, handler) = BuildClient("{\"status\":\"success\"}");
+
+        await client.UpdateOrderNoteAsync(1, "test note", apiKey: "shop3-key");
+
+        Assert.Contains("key=shop3-key", handler.CapturedBody);
+        Assert.DoesNotContain("key=instance-key", handler.CapturedBody);
+    }
+}

--- a/BrickOwlSharp.Tests/BrickOwlClientApiKeyTests.cs
+++ b/BrickOwlSharp.Tests/BrickOwlClientApiKeyTests.cs
@@ -136,4 +136,38 @@ public class BrickOwlClientApiKeyTests
         Assert.Contains("key=shop3-key", handler.CapturedBody);
         Assert.DoesNotContain("key=instance-key", handler.CapturedBody);
     }
+
+    [Fact]
+    public async Task GetOrdersAsync_WithNoKeyAnywhere_ThrowsInvalidOperationException()
+    {
+        BrickOwlClientConfiguration.Instance.ApiKey = null;
+        var (client, _) = BuildClient("[]");
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => client.GetOrdersAsync());
+    }
+
+    [Fact]
+    public async Task Build_WithFactoryApiKey_UsesFactoryKeyWhenNoPerCallKey()
+    {
+        BrickOwlClientConfiguration.Instance.ApiKey = null;
+        var handler = new CapturingHandler("[]");
+        var client = BrickOwlClientFactory.Build(new HttpClient(handler), apiKey: "factory-key");
+
+        await client.GetOrdersAsync();
+
+        Assert.Contains("key=factory-key", handler.CapturedUrl);
+    }
+
+    [Fact]
+    public async Task Build_WithFactoryApiKey_PerCallKeyOverridesFactoryKey()
+    {
+        BrickOwlClientConfiguration.Instance.ApiKey = null;
+        var handler = new CapturingHandler("[]");
+        var client = BrickOwlClientFactory.Build(new HttpClient(handler), apiKey: "factory-key");
+
+        await client.GetOrdersAsync(apiKey: "override-key");
+
+        Assert.Contains("key=override-key", handler.CapturedUrl);
+        Assert.DoesNotContain("key=factory-key", handler.CapturedUrl);
+    }
 }

--- a/BrickOwlSharp.Tests/BrickOwlSharp.Tests.csproj
+++ b/BrickOwlSharp.Tests/BrickOwlSharp.Tests.csproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\BrickOwlSharp.Client\BrickOwlSharp.Client.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/BrickOwlSharp.sln
+++ b/BrickOwlSharp.sln
@@ -7,20 +7,54 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BrickOwlSharp.Demos", "Bric
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BrickOwlSharp.Client", "BrickOwlSharp.Client\BrickOwlSharp.Client.csproj", "{1E70AB31-F7D8-40D2-BE4C-4DF36E968741}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BrickOwlSharp.Tests", "BrickOwlSharp.Tests\BrickOwlSharp.Tests.csproj", "{1DC99F93-5D6C-42A9-A603-EC55652FAC08}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{B4FABD83-76A8-4658-AF01-701DF7737EB7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{B4FABD83-76A8-4658-AF01-701DF7737EB7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B4FABD83-76A8-4658-AF01-701DF7737EB7}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B4FABD83-76A8-4658-AF01-701DF7737EB7}.Debug|x64.Build.0 = Debug|Any CPU
+		{B4FABD83-76A8-4658-AF01-701DF7737EB7}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B4FABD83-76A8-4658-AF01-701DF7737EB7}.Debug|x86.Build.0 = Debug|Any CPU
 		{B4FABD83-76A8-4658-AF01-701DF7737EB7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B4FABD83-76A8-4658-AF01-701DF7737EB7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B4FABD83-76A8-4658-AF01-701DF7737EB7}.Release|x64.ActiveCfg = Release|Any CPU
+		{B4FABD83-76A8-4658-AF01-701DF7737EB7}.Release|x64.Build.0 = Release|Any CPU
+		{B4FABD83-76A8-4658-AF01-701DF7737EB7}.Release|x86.ActiveCfg = Release|Any CPU
+		{B4FABD83-76A8-4658-AF01-701DF7737EB7}.Release|x86.Build.0 = Release|Any CPU
 		{1E70AB31-F7D8-40D2-BE4C-4DF36E968741}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{1E70AB31-F7D8-40D2-BE4C-4DF36E968741}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1E70AB31-F7D8-40D2-BE4C-4DF36E968741}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{1E70AB31-F7D8-40D2-BE4C-4DF36E968741}.Debug|x64.Build.0 = Debug|Any CPU
+		{1E70AB31-F7D8-40D2-BE4C-4DF36E968741}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{1E70AB31-F7D8-40D2-BE4C-4DF36E968741}.Debug|x86.Build.0 = Debug|Any CPU
 		{1E70AB31-F7D8-40D2-BE4C-4DF36E968741}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1E70AB31-F7D8-40D2-BE4C-4DF36E968741}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1E70AB31-F7D8-40D2-BE4C-4DF36E968741}.Release|x64.ActiveCfg = Release|Any CPU
+		{1E70AB31-F7D8-40D2-BE4C-4DF36E968741}.Release|x64.Build.0 = Release|Any CPU
+		{1E70AB31-F7D8-40D2-BE4C-4DF36E968741}.Release|x86.ActiveCfg = Release|Any CPU
+		{1E70AB31-F7D8-40D2-BE4C-4DF36E968741}.Release|x86.Build.0 = Release|Any CPU
+		{1DC99F93-5D6C-42A9-A603-EC55652FAC08}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1DC99F93-5D6C-42A9-A603-EC55652FAC08}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1DC99F93-5D6C-42A9-A603-EC55652FAC08}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{1DC99F93-5D6C-42A9-A603-EC55652FAC08}.Debug|x64.Build.0 = Debug|Any CPU
+		{1DC99F93-5D6C-42A9-A603-EC55652FAC08}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{1DC99F93-5D6C-42A9-A603-EC55652FAC08}.Debug|x86.Build.0 = Debug|Any CPU
+		{1DC99F93-5D6C-42A9-A603-EC55652FAC08}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1DC99F93-5D6C-42A9-A603-EC55652FAC08}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1DC99F93-5D6C-42A9-A603-EC55652FAC08}.Release|x64.ActiveCfg = Release|Any CPU
+		{1DC99F93-5D6C-42A9-A603-EC55652FAC08}.Release|x64.Build.0 = Release|Any CPU
+		{1DC99F93-5D6C-42A9-A603-EC55652FAC08}.Release|x86.ActiveCfg = Release|Any CPU
+		{1DC99F93-5D6C-42A9-A603-EC55652FAC08}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/README.md
+++ b/README.md
@@ -176,6 +176,16 @@ await client.UpdateOrderStatusAsync(orderId, OrderStatus.Processed, apiKey: "<SH
 
 The `apiKey` parameter is available on every method of `IBrickOwlClient` and defaults to `null`, which falls back to `BrickOwlClientConfiguration.Instance.ApiKey`.
 
+Alternatively, create a dedicated client instance per shop by passing `apiKey` to `BrickOwlClientFactory.Build()`. This avoids repeating the key on every call:
+
+```C#
+IBrickOwlClient shopAClient = BrickOwlClientFactory.Build(apiKey: "<SHOP A API KEY>");
+IBrickOwlClient shopBClient = BrickOwlClientFactory.Build(apiKey: "<SHOP B API KEY>");
+
+List<Order> shopAOrders = await shopAClient.GetOrdersAsync();
+List<Order> shopBOrders = await shopBClient.GetOrdersAsync();
+```
+
 ## Inventory
 Add an item to the inventory:
 

--- a/README.md
+++ b/README.md
@@ -153,6 +153,29 @@ foreach (BrickOwlSharp.Client.Color color in allColors)
 }
 ```
 
+## Multiple stores / per-call API key
+By default all calls use the key set on the singleton:
+
+```C#
+BrickOwlClientConfiguration.Instance.ApiKey = "<YOUR API KEY>";
+IBrickOwlClient client = BrickOwlClientFactory.Build();
+```
+
+If you need to serve **multiple BrickOwl shops** from the same process, pass `apiKey` directly to any method. The per-call key takes precedence over the singleton for that single request; all other calls continue using the singleton key.
+
+```C#
+// Shop A uses the singleton key (set once at startup).
+List<Order> shopAOrders = await client.GetOrdersAsync();
+
+// Shop B overrides with its own key for this call only.
+List<Order> shopBOrders = await client.GetOrdersAsync(apiKey: "<SHOP B API KEY>");
+
+// Works identically for write operations.
+await client.UpdateOrderStatusAsync(orderId, OrderStatus.Processed, apiKey: "<SHOP B API KEY>");
+```
+
+The `apiKey` parameter is available on every method of `IBrickOwlClient` and defaults to `null`, which falls back to `BrickOwlClientConfiguration.Instance.ApiKey`.
+
 ## Inventory
 Add an item to the inventory:
 


### PR DESCRIPTION
## ⚠️ Breaking Change

This PR changes the signatures of all methods on `IBrickOwlClient` and `BrickOwlClientFactory.Build()` by adding an `apiKey` parameter. Any existing code that calls these methods by **positional arguments** (rather than named parameters) will break. Callers using named parameters or no arguments are unaffected.

## Summary

- Adds an optional `apiKey` parameter to every method on `IBrickOwlClient`, allowing per-call key overrides without touching the global singleton
- Adds `apiKey` parameter to `BrickOwlClientFactory.Build()` so a dedicated client instance can be created per shop — a cleaner alternative to passing the key on every call
- Adds `ShipCollectionPoint` property to `OrderDetails`
- Refactors `GetOrderAsync` so `_measureRequest` fires individually after each of the two parallel API requests (order details + order items), making the measurement semantics explicit
- Removes the empty, unused `ValidateThrowException` method from `BrickOwlClientConfiguration`
- Updates CI to .NET 10 SDK and adds a test step
- Documents all of the above in README

## Test plan

- [ ] Build passes: `dotnet build`
- [ ] Tests pass: `dotnet test`
- [ ] Verify singleton key still works when no per-call key is provided
- [ ] Verify per-call key overrides the singleton for that single request
- [ ] Verify `BrickOwlClientFactory.Build(apiKey: "...")` creates a client that uses the supplied key as its default

🤖 Generated with [Claude Code](https://claude.com/claude-code)