### PR TITLE
Add update_time parameter to GetOrdersAsync

### DIFF
--- a/BrickOwlSharp.Client/BrickOwlClient.cs
+++ b/BrickOwlSharp.Client/BrickOwlClient.cs
@@ -101,6 +101,7 @@ namespace BrickOwlSharp.Client
         public async Task<List<Order>> GetOrdersAsync(
             OrderStatus? orderStatusFilter = null,
             DateTime? minOrderTime = null,
+            DateTime? minUpdateTime = null,
             int? limit = null,
             OrderType? orderType = null,
             OrderSortType? orderSortType = null,
@@ -117,6 +118,11 @@ namespace BrickOwlSharp.Client
             if (minOrderTime.HasValue)
             {
                 url = AppendOptionalParam(url, "order_time", ((DateTimeOffset)minOrderTime.Value).ToUnixTimeSeconds());
+            }
+
+            if (minUpdateTime.HasValue)
+            {
+                url = AppendOptionalParam(url, "update_time", ((DateTimeOffset)minUpdateTime.Value).ToUnixTimeSeconds());
             }
 
             if (limit.HasValue)

--- a/BrickOwlSharp.Client/IBrickOwlClient.cs
+++ b/BrickOwlSharp.Client/IBrickOwlClient.cs
@@ -50,6 +50,7 @@ namespace BrickOwlSharp.Client
         /// </summary>
         /// <param name="orderStatusFilter">Optional status filter.</param>
         /// <param name="minOrderTime">Optional minimum order time (UTC).</param>
+        /// <param name="minUpdateTime">Optional minimum update time (UTC). Filters orders updated at or after this time.</param>
         /// <param name="limit">Optional limit for the number of orders returned.</param>
         /// <param name="orderType">Optional order list type (store vs customer).</param>
         /// <param name="orderSortType">Optional sort order.</param>
@@ -58,6 +59,7 @@ namespace BrickOwlSharp.Client
         public Task<List<Order>> GetOrdersAsync(
             OrderStatus? orderStatusFilter = null,
             DateTime? minOrderTime = null,
+            DateTime? minUpdateTime = null,
             int? limit = null,
             OrderType? orderType = null,
             OrderSortType? orderSortType = null,

--- a/BrickOwlSharp.Tests/BrickOwlClientApiKeyTests.cs
+++ b/BrickOwlSharp.Tests/BrickOwlClientApiKeyTests.cs
@@ -194,4 +194,17 @@ public class BrickOwlClientApiKeyTests
         Assert.Contains("key=override-key", handler.CapturedUrl);
         Assert.DoesNotContain("key=factory-key", handler.CapturedUrl);
     }
+
+    [Fact]
+    public async Task GetOrdersAsync_WithMinUpdateTime_AppendsUpdateTimeAsUnixTimestamp()
+    {
+        BrickOwlClientConfiguration.Instance.ApiKey = "test-key";
+        var (client, handler) = BuildClient("[]");
+        var updateTime = new DateTime(2024, 1, 15, 12, 0, 0, DateTimeKind.Utc);
+        var expectedTimestamp = ((DateTimeOffset)updateTime).ToUnixTimeSeconds();
+
+        await client.GetOrdersAsync(minUpdateTime: updateTime);
+
+        Assert.Contains($"update_time={expectedTimestamp}", handler.CapturedUrl);
+    }
 }


### PR DESCRIPTION
## Summary

- Adds optional `minUpdateTime` (`DateTime?`) parameter to `GetOrdersAsync` and `IBrickOwlClient`
- Maps to the BrickOwl API's `update_time` query parameter on `/order/list`, which filters orders updated at or after the given time (Unix timestamp)
- Follows the same conversion pattern as the existing `minOrderTime` / `order_time` parameter

## Test plan

- [x] `GetOrdersAsync_WithMinUpdateTime_AppendsUpdateTimeAsUnixTimestamp` — verifies that `update_time` appears in the URL with the correct Unix timestamp value
- [x] All existing tests continue to pass (10/10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)