### PR TITLE
Fix for_sale field dropped from UpdateInventory POST body

### DIFF
--- a/BrickOwlSharp.Client/BrickOwlClient.cs
+++ b/BrickOwlSharp.Client/BrickOwlClient.cs
@@ -790,6 +790,10 @@ namespace BrickOwlSharp.Client
                     ConditionStringConverter csv = new ConditionStringConverter();
                     value = csv.Write((Condition)rawValue);
                 }
+                else if ((converterName == "BoolStringConverter") && (rawValue != null))
+                {
+                    value = ((bool?)rawValue).Value ? "1" : "0";
+                }
                 else if (String.IsNullOrEmpty(converterName) && (rawValue != null))
                 {
                     if (rawValue is decimal v)

--- a/BrickOwlSharp.Tests/BrickOwlClientApiKeyTests.cs
+++ b/BrickOwlSharp.Tests/BrickOwlClientApiKeyTests.cs
@@ -207,4 +207,26 @@ public class BrickOwlClientApiKeyTests
 
         Assert.Contains($"update_time={expectedTimestamp}", handler.CapturedUrl);
     }
+
+    [Fact]
+    public async Task UpdateInventoryAsync_ForSaleFalse_SendsForSaleZeroInBody()
+    {
+        BrickOwlClientConfiguration.Instance.ApiKey = "test-key";
+        var (client, handler) = BuildClient("{\"status\":\"success\"}");
+
+        await client.UpdateInventoryAsync(new UpdateInventory { ForSale = false });
+
+        Assert.Contains("for_sale=0", handler.CapturedBody);
+    }
+
+    [Fact]
+    public async Task UpdateInventoryAsync_ForSaleTrue_SendsForSaleOneInBody()
+    {
+        BrickOwlClientConfiguration.Instance.ApiKey = "test-key";
+        var (client, handler) = BuildClient("{\"status\":\"success\"}");
+
+        await client.UpdateInventoryAsync(new UpdateInventory { ForSale = true });
+
+        Assert.Contains("for_sale=1", handler.CapturedBody);
+    }
 }


### PR DESCRIPTION
## Summary

- `_ObjectToFormData` in `BrickOwlClient.cs` only had a special case for `ConditionStringConverter`; all other custom converters (including `BoolStringConverter`) caused the field to be silently skipped
- `UpdateInventory.ForSale` (`for_sale`) decorated with `[JsonConverter(typeof(BoolStringConverter))]` was never included in the FormData, regardless of value — `false` was effectively ignored
- Added a `BoolStringConverter` branch that maps `true → "1"` and `false → "0"`, matching the converter's JSON serialization behaviour

## Test plan

- [ ] `UpdateInventoryAsync_ForSaleFalse_SendsForSaleZeroInBody` — verifies `for_sale=0` is present in POST body
- [ ] `UpdateInventoryAsync_ForSaleTrue_SendsForSaleOneInBody` — verifies `for_sale=1` is present in POST body
- [ ] All existing tests still pass (`dotnet test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)