### PR TITLE
Add CI workflows for prerelease and release publishing

### DIFF
--- a/.github/actions/nuget-push/action.yml
+++ b/.github/actions/nuget-push/action.yml
@@ -1,0 +1,16 @@
+name: Push to NuGet
+description: Push .nupkg and .snupkg packages from ./nupkgs/ to NuGet
+
+inputs:
+  api-key:
+    description: NuGet API key
+    required: true
+
+runs:
+  using: composite
+  steps:
+  - name: Push packages
+    shell: bash
+    run: |
+      dotnet nuget push ./nupkgs/*.nupkg --api-key "${{ inputs.api-key }}" --source https://api.nuget.org/v3/index.json --skip-duplicate
+      ls ./nupkgs/*.snupkg &>/dev/null && dotnet nuget push ./nupkgs/*.snupkg --api-key "${{ inputs.api-key }}" --source https://api.nuget.org/v3/index.json --skip-duplicate || true

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -28,15 +28,10 @@ jobs:
     - name: Pack (pre-release)
       if: github.event_name == 'push' && github.ref == 'refs/heads/main'
       run: |
-        VERSION=$(grep -oP '(?<=<Version>)[^<]+' BrickOwlSharp.Client/BrickOwlSharp.Client.csproj)
-        if [ -z "$VERSION" ]; then
-          echo "Error: could not extract version from csproj" >&2
-          exit 1
-        fi
         dotnet pack BrickOwlSharp.Client/BrickOwlSharp.Client.csproj \
           --no-build \
           -c Release \
-          -p:Version="${VERSION}-preview.${{ github.run_number }}" \
+          -p:Version="$(dotnet msbuild BrickOwlSharp.Client/BrickOwlSharp.Client.csproj -getProperty:Version)-preview.${{ github.run_number }}" \
           -o ./nupkgs
     - name: Upload prerelease packages
       if: github.event_name == 'push' && github.ref == 'refs/heads/main'
@@ -51,6 +46,7 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/checkout@v4
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
@@ -61,6 +57,6 @@ jobs:
         name: prerelease-packages
         path: ./nupkgs/
     - name: Push to NuGet
-      run: |
-        dotnet nuget push ./nupkgs/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
-        dotnet nuget push ./nupkgs/*.snupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+      uses: ./.github/actions/nuget-push
+      with:
+        api-key: ${{ secrets.NUGET_API_KEY }}

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -6,20 +6,61 @@ on:
   pull_request:
     branches: [ "main" ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Setup .NET
-      uses: actions/setup-dotnet@v2
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 10.0.x
     - name: Restore dependencies
       run: dotnet restore BrickOwlSharp.sln
     - name: Build
-      run: dotnet build BrickOwlSharp.sln --no-restore
+      run: dotnet build BrickOwlSharp.sln --no-restore -c Release
     - name: Test
-      run: dotnet test BrickOwlSharp.Tests/BrickOwlSharp.Tests.csproj --no-build --verbosity normal
+      run: dotnet test BrickOwlSharp.Tests/BrickOwlSharp.Tests.csproj --no-build -c Release --verbosity normal
+    - name: Pack (pre-release)
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      run: |
+        VERSION=$(grep -oP '(?<=<Version>)[^<]+' BrickOwlSharp.Client/BrickOwlSharp.Client.csproj)
+        if [ -z "$VERSION" ]; then
+          echo "Error: could not extract version from csproj" >&2
+          exit 1
+        fi
+        dotnet pack BrickOwlSharp.Client/BrickOwlSharp.Client.csproj \
+          --no-build \
+          -c Release \
+          -p:Version="${VERSION}-preview.${{ github.run_number }}" \
+          -o ./nupkgs
+    - name: Upload prerelease packages
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      uses: actions/upload-artifact@v4
+      with:
+        name: prerelease-packages
+        path: ./nupkgs/
+        retention-days: 1
+
+  publish-prerelease:
+    needs: build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 10.0.x
+    - name: Download prerelease packages
+      uses: actions/download-artifact@v4
+      with:
+        name: prerelease-packages
+        path: ./nupkgs/
+    - name: Push to NuGet
+      run: |
+        dotnet nuget push ./nupkgs/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+        dotnet nuget push ./nupkgs/*.snupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,9 @@
 name: Release
 
 on:
+  push:
+    tags:
+      - 'v[0-9]*.[0-9]*.[0-9]*'
   workflow_dispatch:
     inputs:
       version:
@@ -13,13 +16,13 @@ on:
         type: string
 
 concurrency:
-  group: release-${{ inputs.version }}
+  group: release-${{ github.ref_name }}
   cancel-in-progress: false
 
 jobs:
   release:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
+    if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main'
     permissions:
       contents: write
     steps:
@@ -32,9 +35,18 @@ jobs:
       with:
         dotnet-version: 10.0.x
 
+    - name: Set version from tag or input
+      run: |
+        if [[ "${{ github.ref_type }}" == "tag" ]]; then
+          VERSION="${GITHUB_REF_NAME#v}"
+        else
+          VERSION="${{ inputs.version }}"
+        fi
+        echo "VERSION=${VERSION}" >> $GITHUB_ENV
+
     - name: Validate version format
       env:
-        VERSION: ${{ inputs.version }}
+        VERSION: ${{ env.VERSION }}
       run: |
         if [[ ! "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
           echo "Error: '${VERSION}' is not a valid three-part semver (e.g. 2.1.0)"
@@ -43,7 +55,7 @@ jobs:
 
     - name: Update version in csproj
       env:
-        VERSION: ${{ inputs.version }}
+        VERSION: ${{ env.VERSION }}
         CSPROJ: BrickOwlSharp.Client/BrickOwlSharp.Client.csproj
       run: |
         python3 - <<'EOF'
@@ -70,7 +82,7 @@ jobs:
       if: inputs.release_notes != ''
       env:
         RELEASE_NOTES: ${{ inputs.release_notes }}
-        VERSION: ${{ inputs.version }}
+        VERSION: ${{ env.VERSION }}
       run: |
         python3 - <<'EOF'
         import re, os, html, sys
@@ -105,15 +117,15 @@ jobs:
       run: dotnet pack BrickOwlSharp.Client/BrickOwlSharp.Client.csproj --no-build -c Release -o ./nupkgs
 
     - name: Push to NuGet
-      run: |
-        dotnet nuget push ./nupkgs/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
-        dotnet nuget push ./nupkgs/*.snupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+      uses: ./.github/actions/nuget-push
+      with:
+        api-key: ${{ secrets.NUGET_API_KEY }}
 
     - name: Create GitHub Release
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         RELEASE_NOTES: ${{ inputs.release_notes }}
-        VERSION: ${{ inputs.version }}
+        VERSION: ${{ env.VERSION }}
       run: |
         if gh release view "v${VERSION}" &>/dev/null; then
           echo "GitHub Release v${VERSION} already exists, skipping"
@@ -125,10 +137,11 @@ jobs:
 
     - name: Commit and push version bump
       env:
-        VERSION: ${{ inputs.version }}
+        VERSION: ${{ env.VERSION }}
       run: |
         git config user.name "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"
         git add BrickOwlSharp.Client/BrickOwlSharp.Client.csproj
         git diff --cached --quiet || git commit -m "Release v${VERSION} [skip ci]"
-        git push
+        git pull --rebase origin main
+        git push origin HEAD:main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,134 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version (e.g. 2.1.0)'
+        required: true
+        type: string
+      release_notes:
+        description: 'Release notes (optional, prepended to PackageReleaseNotes in csproj)'
+        required: false
+        type: string
+
+concurrency:
+  group: release-${{ inputs.version }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    permissions:
+      contents: write
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 10.0.x
+
+    - name: Validate version format
+      env:
+        VERSION: ${{ inputs.version }}
+      run: |
+        if [[ ! "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          echo "Error: '${VERSION}' is not a valid three-part semver (e.g. 2.1.0)"
+          exit 1
+        fi
+
+    - name: Update version in csproj
+      env:
+        VERSION: ${{ inputs.version }}
+        CSPROJ: BrickOwlSharp.Client/BrickOwlSharp.Client.csproj
+      run: |
+        python3 - <<'EOF'
+        import re, os, sys
+        csproj = os.environ['CSPROJ']
+        version = os.environ['VERSION']
+        with open(csproj) as f:
+            content = f.read()
+        for pattern, replacement in [
+            (r'<Version>[^<]*</Version>', f'<Version>{version}</Version>'),
+            (r'<AssemblyVersion>[^<]*</AssemblyVersion>', f'<AssemblyVersion>{version}.0</AssemblyVersion>'),
+            (r'<FileVersion>[^<]*</FileVersion>', f'<FileVersion>{version}.0</FileVersion>'),
+        ]:
+            new = re.sub(pattern, replacement, content, count=1)
+            if new == content:
+                print(f"Error: tag not found in csproj: {pattern}", file=sys.stderr)
+                sys.exit(1)
+            content = new
+        with open(csproj, 'w') as f:
+            f.write(content)
+        EOF
+
+    - name: Update release notes in csproj
+      if: inputs.release_notes != ''
+      env:
+        RELEASE_NOTES: ${{ inputs.release_notes }}
+        VERSION: ${{ inputs.version }}
+      run: |
+        python3 - <<'EOF'
+        import re, os, html, sys
+        csproj = 'BrickOwlSharp.Client/BrickOwlSharp.Client.csproj'
+        version = os.environ['VERSION']
+        notes = html.escape(os.environ['RELEASE_NOTES'])
+        with open(csproj) as f:
+            content = f.read()
+        original = content
+        new_entry = f'{version}: {notes}'
+        def replace_notes(m):
+            existing = m.group(1).strip()
+            return f'<PackageReleaseNotes>{new_entry}\n{existing}</PackageReleaseNotes>'
+        content = re.sub(r'<PackageReleaseNotes>(.*?)</PackageReleaseNotes>', replace_notes, content, flags=re.DOTALL)
+        if content == original:
+            print("Error: <PackageReleaseNotes> tag not found in csproj; release notes were not updated", file=sys.stderr)
+            sys.exit(1)
+        with open(csproj, 'w') as f:
+            f.write(content)
+        EOF
+
+    - name: Restore dependencies
+      run: dotnet restore BrickOwlSharp.sln
+
+    - name: Build
+      run: dotnet build BrickOwlSharp.sln --no-restore -c Release
+
+    - name: Test
+      run: dotnet test BrickOwlSharp.Tests/BrickOwlSharp.Tests.csproj --no-build -c Release --verbosity normal
+
+    - name: Pack
+      run: dotnet pack BrickOwlSharp.Client/BrickOwlSharp.Client.csproj --no-build -c Release -o ./nupkgs
+
+    - name: Push to NuGet
+      run: |
+        dotnet nuget push ./nupkgs/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+        dotnet nuget push ./nupkgs/*.snupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+
+    - name: Create GitHub Release
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        RELEASE_NOTES: ${{ inputs.release_notes }}
+        VERSION: ${{ inputs.version }}
+      run: |
+        if gh release view "v${VERSION}" &>/dev/null; then
+          echo "GitHub Release v${VERSION} already exists, skipping"
+        else
+          gh release create "v${VERSION}" \
+            --title "v${VERSION}" \
+            --notes "${RELEASE_NOTES:-Release v${VERSION}}"
+        fi
+
+    - name: Commit and push version bump
+      env:
+        VERSION: ${{ inputs.version }}
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        git add BrickOwlSharp.Client/BrickOwlSharp.Client.csproj
+        git diff --cached --quiet || git commit -m "Release v${VERSION} [skip ci]"
+        git push


### PR DESCRIPTION
## Proposal

**Note:** I'm not familiar with the existing release workflow in this project, so I'm treating this as a proposal for discussion. If you already have an established release process, I'm happy to adapt — or we can close this PR.

This PR adds two GitHub Actions workflows to automate publishing to NuGet, with the goal of making it easier to ship changes faster.

## What's added

### `.github/workflows/dotnet.yml` — extended CI
- Added a `concurrency` group that cancels previous CI runs on the same branch when a new push arrives
- Builds and tests in `Release` configuration (consistent with what gets published)
- On every push to `main`: builds a prerelease package (`<version>-preview.<run_number>`) using `dotnet msbuild -getProperty:Version` to read the base version, uploads it as a CI artifact, and publishes to NuGet — so every merge to `main` is immediately available as a preview version

### `.github/workflows/release.yml` — manual release workflow
- Triggered manually (`workflow_dispatch`) with a version number and optional release notes, or automatically on a `v*.*.*` tag push
- Updates `<Version>`, `<AssemblyVersion>`, `<FileVersion>` in the `.csproj`
- Optionally prepends notes to `<PackageReleaseNotes>`
- Builds, tests, packs, and publishes to NuGet
- Creates a GitHub Release
- Commits the version bump back to `main` with `[skip ci]`

### `.github/actions/nuget-push` — composite action
- Extracted the `dotnet nuget push` commands into a reusable composite action shared by both workflows, so any future change to push flags only needs one edit

## Required secret

`NUGET_API_KEY` — NuGet.org API key, added in Settings → Secrets → Actions.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)