### PR TITLE
Fix: UpdateInventory.ExternalId and UpdateExternalId should be string, not int

### DIFF
--- a/BrickOwlSharp.Client/UpdateInventory.cs
+++ b/BrickOwlSharp.Client/UpdateInventory.cs
@@ -36,7 +36,7 @@ namespace BrickOwlSharp.Client
     public class UpdateInventory
     {
         [JsonPropertyName("external_id")]
-        public int? ExternalId { get; set; }
+        public string ExternalId { get; set; }
 
         [JsonPropertyName("lot_id")]
         public int? LotId { get; set; }

--- a/BrickOwlSharp.Client/UpdateInventory.cs
+++ b/BrickOwlSharp.Client/UpdateInventory.cs
@@ -75,7 +75,7 @@ namespace BrickOwlSharp.Client
         public Condition? Condition { get; set; }
 
         [JsonPropertyName("update_external_id_1")]
-        public int? UpdateExternalId { get; set; }
+        public string UpdateExternalId { get; set; }
 
     }
 }

--- a/BrickOwlSharp.Tests/BrickOwlClientApiKeyTests.cs
+++ b/BrickOwlSharp.Tests/BrickOwlClientApiKeyTests.cs
@@ -229,4 +229,19 @@ public class BrickOwlClientApiKeyTests
 
         Assert.Contains("for_sale=1", handler.CapturedBody);
     }
+
+    [Fact]
+    public async Task UpdateInventoryAsync_ExternalIdSet_SendsExternalIdStringInBody()
+    {
+        // ExternalId is a caller-supplied opaque string tag (e.g. a GUID from the caller's own
+        // system) that BrickOwl's API stores and echoes back verbatim - it was previously typed
+        // as int?, which could not represent a non-numeric external id and was inconsistent with
+        // NewInventory.ExternalId, which is already a string.
+        BrickOwlClientConfiguration.Instance.ApiKey = "test-key";
+        var (client, handler) = BuildClient("{\"status\":\"success\"}");
+
+        await client.UpdateInventoryAsync(new UpdateInventory { ExternalId = "3f9a2b7c-1d4e-4a5b-9c6d-7e8f9a0b1c2d" });
+
+        Assert.Contains("external_id=3f9a2b7c-1d4e-4a5b-9c6d-7e8f9a0b1c2d", handler.CapturedBody);
+    }
 }

--- a/BrickOwlSharp.Tests/BrickOwlClientApiKeyTests.cs
+++ b/BrickOwlSharp.Tests/BrickOwlClientApiKeyTests.cs
@@ -244,4 +244,18 @@ public class BrickOwlClientApiKeyTests
 
         Assert.Contains("external_id=3f9a2b7c-1d4e-4a5b-9c6d-7e8f9a0b1c2d", handler.CapturedBody);
     }
+
+    [Fact]
+    public async Task UpdateInventoryAsync_UpdateExternalIdSet_SendsUpdateExternalIdStringInBody()
+    {
+        // ExternalId/LotId identify which lot the update targets; UpdateExternalId carries the
+        // new external_id value to write onto that lot - it's a value field, not a boolean flag,
+        // so it needs the same string type as ExternalId/NewInventory.ExternalId.
+        BrickOwlClientConfiguration.Instance.ApiKey = "test-key";
+        var (client, handler) = BuildClient("{\"status\":\"success\"}");
+
+        await client.UpdateInventoryAsync(new UpdateInventory { UpdateExternalId = "3f9a2b7c-1d4e-4a5b-9c6d-7e8f9a0b1c2d" });
+
+        Assert.Contains("update_external_id_1=3f9a2b7c-1d4e-4a5b-9c6d-7e8f9a0b1c2d", handler.CapturedBody);
+    }
 }


### PR DESCRIPTION
## Summary

- `UpdateInventory.ExternalId` and `UpdateInventory.UpdateExternalId` were both typed `int?`, but BrickOwl's `inventory/update` endpoint treats these as opaque string tags, not numbers.
- `ExternalId`/`LotId` identify which lot the update applies to; `UpdateExternalId` carries the new `external_id` value to write onto that lot - it's a value field, not a boolean flag, so it needs the same string type.
- `NewInventory.ExternalId` (the create-side equivalent) already models this as `string` - `UpdateInventory` was inconsistent with it on both fields.
- Verified against the real BrickOwl API that these fields are string-typed.

## Change

- `UpdateInventory.ExternalId`: `int?` -> `string`
- `UpdateInventory.UpdateExternalId`: `int?` -> `string`
- Added tests confirming non-numeric string values are sent correctly in the update request body for both fields.

## Breaking change note

This is a small breaking change to `UpdateInventory`'s public API - callers currently assigning an `int` to `ExternalId`/`UpdateExternalId` will need to switch to a `string`. Given these fields' actual purpose (opaque external-system tags, not numeric ids), this brings the type in line with both the real API contract and the sibling `NewInventory.ExternalId` field.

## Test plan

- [x] `dotnet build` - 0 errors, 0 warnings
- [x] `dotnet test` - 14/14 passing (12 pre-existing + 2 new)